### PR TITLE
Fix Leaflet map layout and apply PawPath logo

### DIFF
--- a/assets/pawpath-logo.svg
+++ b/assets/pawpath-logo.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 180" role="img" aria-labelledby="title desc">
+  <title id="title">PawPath</title>
+  <desc id="desc">PawPath logo with a paw-shaped location marker, winding path, and veterinary cross.</desc>
+  <defs>
+    <linearGradient id="hill" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#b9cdbd"/>
+      <stop offset="1" stop-color="#7f9d88"/>
+    </linearGradient>
+  </defs>
+
+  <g transform="translate(4 0)">
+    <path fill="#123f35" d="M90 8c-43 0-72 28-72 69 0 45 42 76 72 96 30-20 72-51 72-96C162 36 133 8 90 8Z"/>
+    <ellipse cx="55" cy="52" rx="15" ry="23" transform="rotate(-24 55 52)" fill="#b9cdbd"/>
+    <ellipse cx="82" cy="40" rx="14" ry="24" transform="rotate(-6 82 40)" fill="#b9cdbd"/>
+    <ellipse cx="110" cy="40" rx="14" ry="24" transform="rotate(6 110 40)" fill="#b9cdbd"/>
+    <ellipse cx="136" cy="54" rx="15" ry="23" transform="rotate(24 136 54)" fill="#b9cdbd"/>
+    <path fill="url(#hill)" d="M43 124c18-20 33-28 49-29 17-1 28 6 45 22 8 8 14 14 18 18-16 17-42 37-65 52-20-13-42-29-59-45 4-5 8-11 12-18Z" opacity=".94"/>
+    <path fill="#fff" d="M62 94c13-10 25-14 38-13 13 1 22 7 31 16-12-3-22-2-31 3-12 7-18 18-20 33-2 15 4 27 13 39-10-7-19-13-28-20-8-17-10-31-5-43 3-7 8-12 15-17-5 0-9 1-13 2Z"/>
+    <path fill="#d8943f" d="M90 70c-14 0-25 11-25 25 0 18 25 35 25 35s25-17 25-35c0-14-11-25-25-25Z"/>
+    <rect x="85" y="81" width="10" height="28" rx="2" fill="#fff"/>
+    <rect x="76" y="90" width="28" height="10" rx="2" fill="#fff"/>
+    <ellipse cx="90" cy="171" rx="39" ry="5" fill="#b9cdbd" opacity=".42"/>
+  </g>
+
+  <text x="198" y="118" font-family="Inter, Avenir Next, Segoe UI, Arial, sans-serif" font-size="92" font-weight="800" letter-spacing="-5">
+    <tspan fill="#123f35">Paw</tspan><tspan fill="#8aa58f">Path</tspan>
+  </text>
+</svg>

--- a/assets/pawpath-mark.svg
+++ b/assets/pawpath-mark.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180" role="img" aria-labelledby="title desc">
+  <title id="title">PawPath brand mark</title>
+  <desc id="desc">A paw-shaped location marker with a winding path and veterinary cross.</desc>
+  <defs>
+    <linearGradient id="hill" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#b9cdbd"/>
+      <stop offset="1" stop-color="#7f9d88"/>
+    </linearGradient>
+  </defs>
+
+  <path fill="#123f35" d="M90 8c-43 0-72 28-72 69 0 45 42 76 72 96 30-20 72-51 72-96C162 36 133 8 90 8Z"/>
+
+  <ellipse cx="55" cy="52" rx="15" ry="23" transform="rotate(-24 55 52)" fill="#b9cdbd"/>
+  <ellipse cx="82" cy="40" rx="14" ry="24" transform="rotate(-6 82 40)" fill="#b9cdbd"/>
+  <ellipse cx="110" cy="40" rx="14" ry="24" transform="rotate(6 110 40)" fill="#b9cdbd"/>
+  <ellipse cx="136" cy="54" rx="15" ry="23" transform="rotate(24 136 54)" fill="#b9cdbd"/>
+
+  <path fill="url(#hill)" d="M43 124c18-20 33-28 49-29 17-1 28 6 45 22 8 8 14 14 18 18-16 17-42 37-65 52-20-13-42-29-59-45 4-5 8-11 12-18Z" opacity=".94"/>
+  <path fill="#fff" d="M62 94c13-10 25-14 38-13 13 1 22 7 31 16-12-3-22-2-31 3-12 7-18 18-20 33-2 15 4 27 13 39-10-7-19-13-28-20-8-17-10-31-5-43 3-7 8-12 15-17-5 0-9 1-13 2Z"/>
+
+  <path fill="#d8943f" d="M90 70c-14 0-25 11-25 25 0 18 25 35 25 35s25-17 25-35c0-14-11-25-25-25Z"/>
+  <rect x="85" y="81" width="10" height="28" rx="2" fill="#fff"/>
+  <rect x="76" y="90" width="28" height="10" rx="2" fill="#fff"/>
+
+  <ellipse cx="90" cy="171" rx="39" ry="5" fill="#b9cdbd" opacity=".42"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -10,14 +10,10 @@
     <meta name="theme-color" content="#173f35" />
     <title>PawPath | Veterinary care wherever you roam</title>
 
-    <link rel="preconnect" href="https://unpkg.com" />
+    <link rel="icon" href="assets/pawpath-mark.svg" type="image/svg+xml" />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" />
     <link rel="preconnect" href="https://tile.openstreetmap.org" />
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-      integrity="sha256-p4NxAoJBhIINfQ3ynhHDpRss0fKt9mLxkL7R2l1Hqvs="
-      crossorigin=""
-    />
+    <link rel="stylesheet" href="leaflet-local.css" />
     <link rel="stylesheet" href="styles.css" />
   </head>
 
@@ -26,11 +22,8 @@
 
     <header class="site-header">
       <a class="brand" href="./" aria-label="PawPath home">
-        <span class="brand-mark" aria-hidden="true">🐾</span>
-        <span>
-          <strong>PawPath</strong>
-          <small>Veterinary care wherever you roam</small>
-        </span>
+        <img class="brand-logo" src="assets/pawpath-logo.svg" alt="PawPath" />
+        <span class="brand-tagline">Veterinary care wherever you roam</span>
       </a>
       <span class="status-badge">Free map access</span>
     </header>
@@ -110,11 +103,8 @@
       </div>
     </template>
 
-    <script
-      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
-      crossorigin=""
-    ></script>
+    <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js" defer></script>
     <script src="app.js" defer></script>
+    <script src="map-layout-fix.js" defer></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <link rel="preconnect" href="https://tile.openstreetmap.org" />
     <link rel="stylesheet" href="leaflet-local.css" />
     <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="site-fixes.css" />
   </head>
 
   <body>

--- a/leaflet-local.css
+++ b/leaflet-local.css
@@ -1,0 +1,383 @@
+/*
+ * Essential Leaflet 1.9.x layout and control styles.
+ * Kept locally so the map remains functional when a CDN stylesheet is blocked.
+ */
+
+.leaflet-pane,
+.leaflet-tile,
+.leaflet-marker-icon,
+.leaflet-marker-shadow,
+.leaflet-tile-container,
+.leaflet-pane > svg,
+.leaflet-pane > canvas,
+.leaflet-zoom-box,
+.leaflet-image-layer,
+.leaflet-layer {
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+.leaflet-container {
+  overflow: hidden;
+  background: #dfe9e3;
+  outline-offset: 1px;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.leaflet-container.leaflet-touch-zoom {
+  touch-action: pan-x pan-y;
+}
+
+.leaflet-container.leaflet-touch-drag {
+  touch-action: none;
+  touch-action: pinch-zoom;
+}
+
+.leaflet-container.leaflet-touch-drag.leaflet-touch-zoom {
+  touch-action: none;
+}
+
+.leaflet-container img.leaflet-image-layer,
+.leaflet-container .leaflet-tile {
+  max-width: none !important;
+  max-height: none !important;
+  width: 256px;
+  height: 256px;
+  padding: 0;
+}
+
+.leaflet-container img.leaflet-tile {
+  mix-blend-mode: plus-lighter;
+}
+
+.leaflet-container.leaflet-safari img.leaflet-tile {
+  mix-blend-mode: normal;
+}
+
+.leaflet-tile,
+.leaflet-marker-icon,
+.leaflet-marker-shadow {
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+.leaflet-tile::selection {
+  background: transparent;
+}
+
+.leaflet-safari .leaflet-tile {
+  image-rendering: -webkit-optimize-contrast;
+}
+
+.leaflet-safari .leaflet-tile-container {
+  width: 1600px;
+  height: 1600px;
+  transform-origin: 0 0;
+}
+
+.leaflet-marker-icon,
+.leaflet-marker-shadow {
+  display: block;
+}
+
+.leaflet-container .leaflet-overlay-pane svg {
+  max-width: none !important;
+  max-height: none !important;
+}
+
+.leaflet-container .leaflet-marker-pane img,
+.leaflet-container .leaflet-shadow-pane img,
+.leaflet-container .leaflet-tile-pane img,
+.leaflet-container img.leaflet-image-layer,
+.leaflet-container .leaflet-tile {
+  max-width: none !important;
+}
+
+.leaflet-container.leaflet-touch-zoom,
+.leaflet-container.leaflet-touch-drag {
+  -ms-touch-action: none;
+}
+
+.leaflet-tile {
+  filter: inherit;
+  visibility: hidden;
+}
+
+.leaflet-tile-loaded {
+  visibility: inherit;
+}
+
+.leaflet-zoom-box {
+  z-index: 800;
+  box-sizing: border-box;
+  width: 0;
+  height: 0;
+  border: 2px dotted #38f;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.leaflet-overlay-pane svg {
+  user-select: none;
+}
+
+.leaflet-pane { z-index: 400; }
+.leaflet-tile-pane { z-index: 200; }
+.leaflet-overlay-pane { z-index: 400; }
+.leaflet-shadow-pane { z-index: 500; }
+.leaflet-marker-pane { z-index: 600; }
+.leaflet-tooltip-pane { z-index: 650; }
+.leaflet-popup-pane { z-index: 700; }
+
+.leaflet-map-pane canvas { z-index: 100; }
+.leaflet-map-pane svg { z-index: 200; }
+
+.leaflet-vml-shape {
+  width: 1px;
+  height: 1px;
+}
+
+.lvml {
+  display: inline-block;
+  position: absolute;
+  behavior: url(#default#VML);
+}
+
+.leaflet-control {
+  position: relative;
+  z-index: 800;
+  pointer-events: auto;
+}
+
+.leaflet-top,
+.leaflet-bottom {
+  position: absolute;
+  z-index: 1000;
+  pointer-events: none;
+}
+
+.leaflet-top { top: 0; }
+.leaflet-right { right: 0; }
+.leaflet-bottom { bottom: 0; }
+.leaflet-left { left: 0; }
+
+.leaflet-control {
+  float: left;
+  clear: both;
+}
+
+.leaflet-right .leaflet-control { float: right; }
+
+.leaflet-top .leaflet-control { margin-top: 12px; }
+.leaflet-bottom .leaflet-control { margin-bottom: 12px; }
+.leaflet-left .leaflet-control { margin-left: 12px; }
+.leaflet-right .leaflet-control { margin-right: 12px; }
+
+.leaflet-fade-anim .leaflet-popup {
+  opacity: 0;
+  transition: opacity 0.2s linear;
+}
+
+.leaflet-fade-anim .leaflet-map-pane .leaflet-popup {
+  opacity: 1;
+}
+
+.leaflet-zoom-animated {
+  transform-origin: 0 0;
+}
+
+svg.leaflet-zoom-animated {
+  will-change: transform;
+}
+
+.leaflet-zoom-anim .leaflet-zoom-animated {
+  transition: transform 0.25s cubic-bezier(0, 0, 0.25, 1);
+}
+
+.leaflet-zoom-anim .leaflet-tile,
+.leaflet-pan-anim .leaflet-tile {
+  transition: none;
+}
+
+.leaflet-zoom-anim .leaflet-zoom-hide {
+  visibility: hidden;
+}
+
+.leaflet-interactive {
+  cursor: pointer;
+}
+
+.leaflet-grab {
+  cursor: grab;
+}
+
+.leaflet-crosshair,
+.leaflet-crosshair .leaflet-interactive {
+  cursor: crosshair;
+}
+
+.leaflet-popup-pane,
+.leaflet-control {
+  cursor: auto;
+}
+
+.leaflet-dragging .leaflet-grab,
+.leaflet-dragging .leaflet-grab .leaflet-interactive {
+  cursor: grabbing;
+}
+
+.leaflet-marker-icon,
+.leaflet-marker-shadow,
+.leaflet-image-layer,
+.leaflet-pane > svg path,
+.leaflet-tile-container {
+  pointer-events: none;
+}
+
+.leaflet-marker-icon.leaflet-interactive,
+.leaflet-image-layer.leaflet-interactive,
+.leaflet-pane > svg path.leaflet-interactive,
+svg.leaflet-image-layer.leaflet-interactive path {
+  pointer-events: auto;
+}
+
+.leaflet-bar {
+  border: 1px solid rgba(16, 45, 38, 0.18);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(16, 45, 38, 0.16);
+}
+
+.leaflet-bar a {
+  display: block;
+  width: 34px;
+  height: 34px;
+  border-bottom: 1px solid #d9e2dd;
+  background: #fff;
+  color: #173f35;
+  font: 700 20px/34px Arial, Helvetica, sans-serif;
+  text-align: center;
+  text-decoration: none;
+}
+
+.leaflet-bar a:first-child {
+  border-top-left-radius: 11px;
+  border-top-right-radius: 11px;
+}
+
+.leaflet-bar a:last-child {
+  border-bottom: 0;
+  border-bottom-left-radius: 11px;
+  border-bottom-right-radius: 11px;
+}
+
+.leaflet-bar a:hover,
+.leaflet-bar a:focus {
+  background: #f3f7f4;
+}
+
+.leaflet-bar a.leaflet-disabled {
+  cursor: default;
+  background: #f3f7f4;
+  color: #a7b0ac;
+}
+
+.leaflet-control-zoom-in,
+.leaflet-control-zoom-out {
+  text-indent: 1px;
+}
+
+.leaflet-touch .leaflet-bar a {
+  width: 36px;
+  height: 36px;
+  line-height: 36px;
+}
+
+.leaflet-control-attribution {
+  margin: 0;
+  padding: 3px 7px;
+  background: rgba(255, 255, 255, 0.88);
+  color: #44534e;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.leaflet-control-attribution a {
+  color: #205346;
+}
+
+.leaflet-popup {
+  position: absolute;
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+.leaflet-popup-content-wrapper {
+  border-radius: 14px;
+  background: #fff;
+  color: #1e2b27;
+  box-shadow: 0 10px 28px rgba(16, 45, 38, 0.2);
+  text-align: left;
+}
+
+.leaflet-popup-content {
+  margin: 14px 16px;
+  min-width: 150px;
+  line-height: 1.45;
+}
+
+.leaflet-popup-content p {
+  margin: 1em 0;
+}
+
+.leaflet-popup-tip-container {
+  position: absolute;
+  left: 50%;
+  width: 40px;
+  height: 20px;
+  margin-left: -20px;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.leaflet-popup-tip {
+  width: 17px;
+  height: 17px;
+  margin: -10px auto 0;
+  padding: 1px;
+  transform: rotate(45deg);
+  background: #fff;
+  box-shadow: 3px 3px 10px rgba(16, 45, 38, 0.15);
+}
+
+.leaflet-container a.leaflet-popup-close-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 28px;
+  height: 28px;
+  padding: 4px 4px 0 0;
+  border: 0;
+  background: transparent;
+  color: #6a7772;
+  font: 20px/24px Tahoma, Verdana, sans-serif;
+  text-align: center;
+  text-decoration: none;
+}
+
+.leaflet-container a.leaflet-popup-close-button:hover,
+.leaflet-container a.leaflet-popup-close-button:focus {
+  color: #173f35;
+}
+
+.leaflet-tooltip {
+  position: absolute;
+  padding: 6px;
+  border: 1px solid #fff;
+  border-radius: 4px;
+  background: #fff;
+  color: #222;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  user-select: none;
+  pointer-events: none;
+  white-space: nowrap;
+}

--- a/map-layout-fix.js
+++ b/map-layout-fix.js
@@ -1,0 +1,30 @@
+/* Keep Leaflet synchronized with responsive layout changes. */
+
+document.addEventListener("DOMContentLoaded", () => {
+  const mapElement = document.getElementById("map");
+  if (!mapElement) return;
+
+  let resizeFrame;
+
+  const refreshMap = () => {
+    cancelAnimationFrame(resizeFrame);
+    resizeFrame = requestAnimationFrame(() => {
+      if (typeof map !== "undefined" && map && typeof map.invalidateSize === "function") {
+        map.invalidateSize({ pan: false, debounceMoveend: true });
+      }
+    });
+  };
+
+  refreshMap();
+  setTimeout(refreshMap, 150);
+  setTimeout(refreshMap, 600);
+  window.addEventListener("load", refreshMap, { once: true });
+  window.addEventListener("resize", refreshMap, { passive: true });
+  window.addEventListener("orientationchange", refreshMap, { passive: true });
+
+  if ("ResizeObserver" in window) {
+    const observer = new ResizeObserver(refreshMap);
+    observer.observe(mapElement);
+    if (mapElement.parentElement) observer.observe(mapElement.parentElement);
+  }
+});

--- a/site-fixes.css
+++ b/site-fixes.css
@@ -1,0 +1,87 @@
+/* PawPath brand integration and defensive map sizing. */
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.brand-logo {
+  display: block;
+  width: clamp(190px, 18vw, 250px);
+  height: auto;
+}
+
+.brand-tagline {
+  max-width: 150px;
+  color: var(--ink-500);
+  font-size: 0.76rem;
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+/*
+ * Give Leaflet an explicit, stable rectangle. Percentage-only map heights can
+ * change after results render, leaving Leaflet with stale tile coordinates.
+ */
+.discovery-layout {
+  height: clamp(620px, 72vh, 780px);
+  min-height: 620px;
+}
+
+.map-panel {
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+#map {
+  position: absolute;
+  inset: 0;
+  width: auto;
+  height: auto;
+  min-height: 0;
+}
+
+.leaflet-container {
+  width: 100%;
+  height: 100%;
+  font: inherit;
+}
+
+.leaflet-tile-container,
+.leaflet-tile {
+  will-change: transform;
+}
+
+@media (max-width: 780px) {
+  .brand-logo {
+    width: 176px;
+  }
+
+  .brand-tagline {
+    display: none;
+  }
+
+  .discovery-layout {
+    height: auto;
+    min-height: 0;
+  }
+
+  .map-panel {
+    position: relative;
+    height: 54vh;
+    min-height: 380px;
+  }
+}
+
+@media (max-width: 460px) {
+  .brand-logo {
+    width: 154px;
+  }
+
+  .status-badge {
+    display: none;
+  }
+}


### PR DESCRIPTION
## What changed

- added a locally hosted Leaflet layout stylesheet so map tiles and controls do not depend on a remote CSS request
- added defensive map sizing to keep the map inside one stable desktop and mobile rectangle
- added a `ResizeObserver` and delayed `invalidateSize()` calls so Leaflet recalculates after responsive layout changes, browser zoom, page load, and device rotation
- switched the Leaflet JavaScript CDN from unpkg to jsDelivr
- added a new horizontal PawPath SVG logo and standalone SVG brand mark
- applied the horizontal logo in the site header and the brand mark as the browser favicon

## Root cause

The screenshot shows Leaflet JavaScript running without its required positioning styles. Without those styles, 256-pixel map tiles remain in normal document flow and appear as disconnected strips. A changing percentage-based map height can also leave Leaflet using stale dimensions.

## Validation

- branch is based directly on the current `main` commit with no divergence
- changes are limited to the map presentation, logo assets, and header integration
- the map no longer relies on an externally hosted Leaflet stylesheet
- the original clinic search and OpenStreetMap/Overpass application logic is unchanged

The live GitHub Pages deployment should be checked after merge with a hard refresh to clear the previously cached HTML and CSS.