### PR TITLE
Use uploaded PNG PawPath brand assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <meta name="theme-color" content="#173f35" />
     <title>PawPath | Veterinary care wherever you roam</title>
 
-    <link rel="icon" href="assets/pawpath-mark.svg" type="image/svg+xml" />
+    <link rel="icon" href="assets/PawPath_mark_transparent.png" type="image/png" />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" />
     <link rel="preconnect" href="https://tile.openstreetmap.org" />
     <link rel="stylesheet" href="leaflet-local.css" />
@@ -23,7 +23,7 @@
 
     <header class="site-header">
       <a class="brand" href="./" aria-label="PawPath home">
-        <img class="brand-logo" src="assets/pawpath-logo.svg" alt="PawPath" />
+        <img class="brand-logo" src="assets/PawPath_logo_Transparent.png" alt="PawPath" />
         <span class="brand-tagline">Veterinary care wherever you roam</span>
       </a>
       <span class="status-badge">Free map access</span>


### PR DESCRIPTION
## What changed

- updated the browser favicon to `assets/PawPath_mark_transparent.png`
- updated the header logo to `assets/PawPath_logo_Transparent.png`
- removed the active page references to the SVG logo files

## Validation

- confirmed both PNG files exist in the repository with the exact case-sensitive filenames
- branch changes only `index.html`