### PR TITLE
Add Plan a Trip and Find Care Now modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ PawPath is a mobile-friendly web application for campers, RV travelers, road-tri
 
 [Open PawPath](https://jeffthomasiii.github.io/pawpath/)
 
-The current proof of concept establishes the mapping and live-search foundation. The next development phase will add trip care plans, primary and backup facility selection, confidence indicators, Emergency Mode, and a printable emergency card.
+The proof of concept now presents two distinct workflows: **Plan a Trip** for destination-based preparation and **Find Care Now** for immediate nearby-care access. Upcoming increments will add facility details, confidence indicators, primary and backup selection, saved care plans, Emergency Mode, and a printable emergency card.
 
 ## Why PawPath?
 
@@ -45,6 +45,9 @@ Use the current location to prioritize likely emergency-care options and quickly
 
 ## Current capabilities
 
+- Switch between Plan a Trip and Find Care Now modes
+- Use destination-focused search language and actions for trip preparation
+- Emphasize current-location access for immediate nearby-care searches
 - Search by U.S. city, state, or ZIP code
 - Use browser geolocation to search near the current position
 - View veterinary clinics on an interactive Leaflet map
@@ -52,14 +55,13 @@ Use the current location to prioritize likely emergency-care options and quickly
 - Select a clinic card to center and open its map marker
 - Open driving directions without embedding a paid map service
 - Responsive desktop, tablet, and mobile layouts
-- Keyboard-accessible controls, cards, and map markers
+- Keyboard-accessible mode controls, search controls, cards, and map markers
 - PawPath branded header and favicon
 
 ## Next proof-of-concept capabilities
 
-The `v0.2 – Care Plan POC` phase will add:
+The remaining `v0.2 – Care Plan POC` work will add:
 
-- Plan a Trip and Find Care Now modes
 - Facility-detail panels
 - Care-type and confidence indicators
 - Primary and backup facility selection
@@ -74,7 +76,7 @@ See [Proof-of-Concept Scope](docs/POC_SCOPE.md) and [Roadmap](docs/ROADMAP.md).
 
 Phase 1 work is tracked in the [`v0.2 Care Plan POC` tracking issue](https://github.com/jeffthomasiii/pawpath/issues/13), with one issue for each feature package and its acceptance criteria.
 
-The first implementation task is [POC-01: Add Plan a Trip and Find Care Now modes](https://github.com/jeffthomasiii/pawpath/issues/4).
+The next implementation task is [POC-02: Add facility detail and confidence states](https://github.com/jeffthomasiii/pawpath/issues/5).
 
 ## Product documentation
 
@@ -109,9 +111,9 @@ pawpath/
 ├── docs/                    # Product vision, POC scope, roadmap, backlog, and demo documentation
 ├── index.html               # Semantic application layout
 ├── styles.css               # Core responsive design system and components
-├── site-fixes.css           # Map and brand-layout corrections
+├── site-fixes.css           # Map, brand, and mode-layout enhancements
 ├── leaflet-local.css        # Locally hosted Leaflet layout styles
-├── app.js                   # Map, geocoding, clinic search, filters, and UI state
+├── app.js                   # Modes, map, geocoding, clinic search, filters, and UI state
 ├── map-layout-fix.js        # Defensive Leaflet resize handling
 └── README.md                # Project overview
 ```

--- a/app.js
+++ b/app.js
@@ -3,10 +3,43 @@ const SEARCH_RADIUS_METERS = 12000;
 const NOMINATIM_ENDPOINT = "https://nominatim.openstreetmap.org/search";
 const OVERPASS_ENDPOINT = "https://overpass-api.de/api/interpreter";
 
+const MODE_CONTENT = {
+  plan: {
+    eyebrow: "Pet-care preparedness for the road",
+    title: "Make a pet-care plan before you travel.",
+    description:
+      "Search a campground, destination, city, or ZIP code. Review nearby veterinary care now so you know where to call and where to go before your trip begins.",
+    inputLabel: "Where are you going?",
+    placeholder: "Campground, city, state, or ZIP code",
+    searchButton: "Explore destination",
+    locationButton: "Use current location instead",
+    guidance: "Start with where you will stay. PawPath will show care options near that destination.",
+    resultsEyebrow: "Trip planning",
+    emptySearchMessage: "Enter a campground, destination, city, state, or ZIP code to search.",
+    announcement: "Plan a Trip selected. Search a destination to prepare veterinary care options before you leave.",
+  },
+  now: {
+    eyebrow: "When your pet needs care away from home",
+    title: "Find nearby pet care now.",
+    description:
+      "Use your current location to quickly find veterinary and likely emergency care. Review the options, call ahead, and open directions when you are ready to go.",
+    inputLabel: "Where should we search?",
+    placeholder: "City, state, or ZIP code",
+    searchButton: "Search this area",
+    locationButton: "Find care near me",
+    guidance: "For the fastest nearby search, use your current location. Location access stays in your browser.",
+    resultsEyebrow: "Nearby care",
+    emptySearchMessage: "Enter a city, state, or ZIP code, or use your current location.",
+    announcement: "Find Care Now selected. Use your current location or search an area for nearby veterinary care.",
+  },
+};
+
 let map;
 let markerLayer;
 let clinics = [];
 let activeFilter = "all";
+let activeMode = "plan";
+let currentSearchLabel = DEFAULT_LOCATION.label;
 let selectedClinicId = null;
 const markersById = new Map();
 
@@ -18,17 +51,30 @@ function initApp() {
   cacheElements();
   initializeMap();
   bindEvents();
+  setMode("plan");
   elements.currentYear.textContent = new Date().getFullYear();
   searchNearby(DEFAULT_LOCATION, DEFAULT_LOCATION.label);
 }
 
 function cacheElements() {
+  elements.heroPanel = document.getElementById("hero-panel");
+  elements.modeButtons = [...document.querySelectorAll("[data-mode]")];
+  elements.modeStatus = document.getElementById("mode-status");
+  elements.heroEyebrow = document.getElementById("hero-eyebrow");
+  elements.pageTitle = document.getElementById("page-title");
+  elements.heroDescription = document.getElementById("hero-description");
+  elements.locationLabel = document.getElementById("location-label");
   elements.searchForm = document.getElementById("search-form");
   elements.locationInput = document.getElementById("location-input");
+  elements.searchButton = document.getElementById("search-btn");
+  elements.searchButtonLabel = document.getElementById("search-button-label");
   elements.locationButton = document.getElementById("loc-btn");
+  elements.locationButtonLabel = document.getElementById("location-button-label");
+  elements.modeGuidance = document.getElementById("mode-guidance");
   elements.formMessage = document.getElementById("form-message");
   elements.clinicList = document.getElementById("clinic-list");
   elements.resultCount = document.getElementById("result-count");
+  elements.resultsEyebrow = document.getElementById("results-eyebrow");
   elements.resultsTitle = document.getElementById("results-title");
   elements.emptyTemplate = document.getElementById("empty-state-template");
   elements.filterButtons = [...document.querySelectorAll("[data-filter]")];
@@ -56,6 +102,11 @@ function bindEvents() {
   elements.searchForm.addEventListener("submit", handleSearchSubmit);
   elements.locationButton.addEventListener("click", handleGeolocation);
 
+  elements.modeButtons.forEach((button, index) => {
+    button.addEventListener("click", () => setMode(button.dataset.mode, true));
+    button.addEventListener("keydown", (event) => handleModeKeydown(event, index));
+  });
+
   elements.filterButtons.forEach((button) => {
     button.addEventListener("click", () => {
       activeFilter = button.dataset.filter;
@@ -69,12 +120,62 @@ function bindEvents() {
   });
 }
 
+function handleModeKeydown(event, currentIndex) {
+  if (!["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End"].includes(event.key)) return;
+
+  event.preventDefault();
+  let nextIndex = currentIndex;
+
+  if (event.key === "Home") nextIndex = 0;
+  if (event.key === "End") nextIndex = elements.modeButtons.length - 1;
+  if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+    nextIndex = (currentIndex - 1 + elements.modeButtons.length) % elements.modeButtons.length;
+  }
+  if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+    nextIndex = (currentIndex + 1) % elements.modeButtons.length;
+  }
+
+  const nextButton = elements.modeButtons[nextIndex];
+  nextButton.focus();
+  setMode(nextButton.dataset.mode, true);
+}
+
+function setMode(mode, announce = false) {
+  if (!MODE_CONTENT[mode]) return;
+
+  activeMode = mode;
+  const content = MODE_CONTENT[mode];
+
+  elements.heroPanel.dataset.mode = mode;
+  elements.modeButtons.forEach((button) => {
+    const isActive = button.dataset.mode === mode;
+    button.classList.toggle("is-active", isActive);
+    button.setAttribute("aria-pressed", String(isActive));
+  });
+
+  elements.heroEyebrow.textContent = content.eyebrow;
+  elements.pageTitle.textContent = content.title;
+  elements.heroDescription.textContent = content.description;
+  elements.locationLabel.textContent = content.inputLabel;
+  elements.locationInput.placeholder = content.placeholder;
+  elements.searchButtonLabel.textContent = content.searchButton;
+  elements.locationButtonLabel.textContent = content.locationButton;
+  elements.modeGuidance.textContent = content.guidance;
+  elements.resultsEyebrow.textContent = content.resultsEyebrow;
+  updateResultsHeading();
+  setMessage("");
+
+  if (announce) {
+    elements.modeStatus.textContent = content.announcement;
+  }
+}
+
 async function handleSearchSubmit(event) {
   event.preventDefault();
   const query = elements.locationInput.value.trim();
 
   if (!query) {
-    setMessage("Enter a city, state, or ZIP code to search.", true);
+    setMessage(MODE_CONTENT[activeMode].emptySearchMessage, true);
     elements.locationInput.focus();
     return;
   }
@@ -153,16 +254,29 @@ async function searchNearby(center, label) {
 
   try {
     clinics = await fetchVeterinaryClinics(center);
+    currentSearchLabel = label || "this area";
     selectedClinicId = null;
     activeFilter = "all";
     resetFilters();
-    elements.resultsTitle.textContent = label ? `Care near ${shortenLabel(label)}` : "Veterinary clinics";
+    updateResultsHeading();
     renderClinics();
-    setMessage(`Showing veterinary care near ${label}.`);
+    setMessage(
+      activeMode === "plan"
+        ? `Showing care options near ${label}. Review these choices before your trip and call ahead to confirm services.`
+        : `Showing veterinary care near ${label}. Call ahead before you travel.`
+    );
   } catch (error) {
     console.error("Clinic lookup failed:", error);
     showSearchError("Clinic data is temporarily unavailable. Please try again in a moment.");
   }
+}
+
+function updateResultsHeading() {
+  if (!elements.resultsTitle) return;
+  const label = shortenLabel(currentSearchLabel);
+  elements.resultsTitle.textContent = activeMode === "plan"
+    ? `Care options near ${label}`
+    : `Care near ${label}`;
 }
 
 async function fetchVeterinaryClinics(center) {

--- a/app.js
+++ b/app.js
@@ -58,7 +58,7 @@ function initApp() {
 
 function cacheElements() {
   elements.heroPanel = document.getElementById("hero-panel");
-  elements.modeButtons = [...document.querySelectorAll("[data-mode]")];
+  elements.modeButtons = [...document.querySelectorAll(".mode-option[data-mode]")];
   elements.modeStatus = document.getElementById("mode-status");
   elements.heroEyebrow = document.getElementById("hero-eyebrow");
   elements.pageTitle = document.getElementById("page-title");

--- a/index.html
+++ b/index.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="Find nearby veterinary clinics and emergency animal hospitals while traveling with pets."
+      content="Plan veterinary and emergency pet-care options before a trip, or find nearby care when you need it."
     />
     <meta name="theme-color" content="#173f35" />
-    <title>PawPath | Veterinary care wherever you roam</title>
+    <title>PawPath | Pet-care preparedness for the road</title>
 
     <link rel="icon" href="assets/PawPath_mark_transparent.png" type="image/png" />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" />
@@ -24,24 +24,41 @@
     <header class="site-header">
       <a class="brand" href="./" aria-label="PawPath home">
         <img class="brand-logo" src="assets/PawPath_logo_Transparent.png" alt="PawPath" />
-        <span class="brand-tagline">Veterinary care wherever you roam</span>
+        <span class="brand-tagline">Pet-care preparedness for the road</span>
       </a>
       <span class="status-badge">Free map access</span>
     </header>
 
     <main id="main-content" class="app-shell">
-      <section class="hero-panel" aria-labelledby="page-title">
+      <section id="hero-panel" class="hero-panel" data-mode="plan" aria-labelledby="page-title">
+        <div class="mode-selector" role="group" aria-label="Choose how you want to use PawPath">
+          <button class="mode-option is-active" type="button" data-mode="plan" aria-pressed="true">
+            <span class="mode-option-icon" aria-hidden="true">⌖</span>
+            <span>
+              <strong>Plan a Trip</strong>
+              <small>Prepare care options before you leave.</small>
+            </span>
+          </button>
+          <button class="mode-option" type="button" data-mode="now" aria-pressed="false">
+            <span class="mode-option-icon" aria-hidden="true">✚</span>
+            <span>
+              <strong>Find Care Now</strong>
+              <small>Quickly search around your current location.</small>
+            </span>
+          </button>
+        </div>
+
         <div class="hero-copy">
-          <p class="eyebrow">Built for road trips, campgrounds, and everyday adventures</p>
-          <h1 id="page-title">Find trusted pet care nearby.</h1>
-          <p>
-            Search any U.S. city or ZIP code, or use your current location to find veterinary clinics and
-            emergency animal hospitals.
+          <p id="hero-eyebrow" class="eyebrow">Pet-care preparedness for the road</p>
+          <h1 id="page-title">Make a pet-care plan before you travel.</h1>
+          <p id="hero-description">
+            Search a campground, destination, city, or ZIP code. Review nearby veterinary care now so you know
+            where to call and where to go before your trip begins.
           </p>
         </div>
 
         <form id="search-form" class="search-card" novalidate>
-          <label for="location-input">Where are you traveling?</label>
+          <label id="location-label" for="location-input">Where are you going?</label>
           <div class="search-row">
             <div class="input-wrap">
               <span aria-hidden="true">⌕</span>
@@ -50,25 +67,31 @@
                 name="location"
                 type="search"
                 autocomplete="postal-code"
-                placeholder="City, state, or ZIP code"
+                placeholder="Campground, city, state, or ZIP code"
               />
             </div>
-            <button class="button button-primary" type="submit" id="search-btn">Search</button>
+            <button class="button button-primary" type="submit" id="search-btn">
+              <span id="search-button-label">Explore destination</span>
+            </button>
             <button class="button button-secondary" type="button" id="loc-btn">
               <span aria-hidden="true">◎</span>
-              Use my location
+              <span id="location-button-label">Use current location instead</span>
             </button>
           </div>
+          <p id="mode-guidance" class="mode-guidance">
+            Start with where you will stay. PawPath will show care options near that destination.
+          </p>
           <p id="form-message" class="form-message" role="status" aria-live="polite"></p>
         </form>
+        <p id="mode-status" class="sr-only" aria-live="polite"></p>
       </section>
 
       <section class="discovery-layout" aria-label="Veterinary clinic finder">
         <aside class="results-panel" aria-labelledby="results-title">
           <div class="results-heading">
             <div>
-              <p class="eyebrow">Nearby care</p>
-              <h2 id="results-title">Veterinary clinics</h2>
+              <p id="results-eyebrow" class="eyebrow">Trip planning</p>
+              <h2 id="results-title">Care options near Moreno Valley, California</h2>
             </div>
             <span id="result-count" class="result-count">Loading…</span>
           </div>

--- a/site-fixes.css
+++ b/site-fixes.css
@@ -55,6 +55,132 @@
   will-change: transform;
 }
 
+/* Phase 1 mode selector: planning first, urgent access when needed. */
+.mode-selector {
+  position: relative;
+  z-index: 2;
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  padding: 7px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 20px;
+  background: rgba(5, 30, 24, 0.28);
+  backdrop-filter: blur(12px);
+}
+
+.mode-option {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  min-height: 74px;
+  padding: 12px 15px;
+  border: 1px solid transparent;
+  border-radius: 15px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.76);
+  cursor: pointer;
+  text-align: left;
+  transition: background 160ms ease, color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+}
+
+.mode-option:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--white);
+}
+
+.mode-option.is-active {
+  background: var(--white);
+  color: var(--forest-950);
+  box-shadow: 0 10px 28px rgba(5, 30, 24, 0.18);
+}
+
+.mode-option:focus-visible {
+  outline: 3px solid rgba(216, 148, 63, 0.72);
+  outline-offset: 3px;
+}
+
+.mode-option-icon {
+  display: grid;
+  flex: 0 0 auto;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  border: 1px solid currentColor;
+  border-radius: 13px;
+  font-size: 1.15rem;
+  font-weight: 900;
+}
+
+.mode-option.is-active .mode-option-icon {
+  border-color: rgba(23, 63, 53, 0.16);
+  background: var(--sage-100);
+  color: var(--forest-900);
+}
+
+.mode-option strong,
+.mode-option small {
+  display: block;
+}
+
+.mode-option strong {
+  font-size: 0.96rem;
+  line-height: 1.2;
+}
+
+.mode-option small {
+  margin-top: 3px;
+  color: inherit;
+  font-size: 0.76rem;
+  line-height: 1.3;
+  opacity: 0.78;
+}
+
+.mode-guidance {
+  margin: 10px 2px 0;
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.8rem;
+}
+
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+.hero-panel[data-mode="now"] {
+  background:
+    radial-gradient(circle at 92% 8%, rgba(216, 148, 63, 0.34), transparent 30%),
+    linear-gradient(135deg, #102d26, #285f50);
+}
+
+.hero-panel[data-mode="now"] #search-btn {
+  border-color: rgba(255, 255, 255, 0.42);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--white);
+}
+
+.hero-panel[data-mode="now"] #search-btn:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.hero-panel[data-mode="now"] #loc-btn {
+  border-color: transparent;
+  background: var(--amber-500);
+  color: var(--forest-950);
+}
+
+.hero-panel[data-mode="now"] #loc-btn:hover {
+  background: #e2a554;
+}
+
 @media (max-width: 780px) {
   .brand-logo {
     width: 176px;
@@ -73,6 +199,30 @@
     position: relative;
     height: 54vh;
     min-height: 380px;
+  }
+
+  .mode-selector {
+    border-radius: 17px;
+  }
+
+  .mode-option {
+    min-height: 68px;
+    padding: 10px 12px;
+  }
+
+  .mode-option-icon {
+    width: 38px;
+    height: 38px;
+  }
+}
+
+@media (max-width: 620px) {
+  .mode-selector {
+    grid-template-columns: 1fr;
+  }
+
+  .mode-option {
+    min-height: 62px;
   }
 }
 


### PR DESCRIPTION
## What changed

- added a prominent two-option mode selector above the search experience
- made **Plan a Trip** the default workflow with destination-focused copy and actions
- added **Find Care Now** with current-location access presented as the primary action
- update the headline, supporting copy, input label, placeholder, buttons, guidance, and results context when modes change
- added arrow-key, Home, and End navigation between mode controls
- preserved the existing Leaflet map, destination search, geolocation, filters, cards, markers, and directions behavior
- added responsive mode-selector styling and screen-reader announcements
- updated the README to reflect the completed capability and point to the next POC increment

## Validation

- `node --check app.js`
- parsed `index.html` with Python's HTML parser
- confirmed balanced CSS blocks
- reviewed branch diff against `main`
- branch is cleanly ahead of `main` with changes limited to `index.html`, `app.js`, `site-fixes.css`, and `README.md`

Closes #4