### PR TITLE
Add facility details and confidence states

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ PawPath is a mobile-friendly web application for campers, RV travelers, road-tri
 
 [Open PawPath](https://jeffthomasiii.github.io/pawpath/)
 
-The proof of concept now presents two distinct workflows: **Plan a Trip** for destination-based preparation and **Find Care Now** for immediate nearby-care access. Upcoming increments will add facility details, confidence indicators, primary and backup selection, saved care plans, Emergency Mode, and a printable emergency card.
+The proof of concept now presents two distinct workflows: **Plan a Trip** for destination-based preparation and **Find Care Now** for immediate nearby-care access. Selecting a result opens a facility-detail view with conservative care classification, confidence explanations, source disclosure, and call-ahead guidance. Upcoming increments will add primary and backup selection, saved care plans, Emergency Mode, and a printable emergency card.
 
 ## Why PawPath?
 
@@ -48,6 +48,10 @@ Use the current location to prioritize likely emergency-care options and quickly
 - Switch between Plan a Trip and Find Care Now modes
 - Use destination-focused search language and actions for trip preparation
 - Emphasize current-location access for immediate nearby-care searches
+- Open the same facility-detail experience from a result card or map marker
+- Classify facilities conservatively as emergency, urgent, routine, or unknown
+- Show confidence states and plain-language explanations without relying only on color
+- Display missing information, OpenStreetMap source links, and call-ahead guidance honestly
 - Search by U.S. city, state, or ZIP code
 - Use browser geolocation to search near the current position
 - View veterinary clinics on an interactive Leaflet map
@@ -55,15 +59,13 @@ Use the current location to prioritize likely emergency-care options and quickly
 - Select a clinic card to center and open its map marker
 - Open driving directions without embedding a paid map service
 - Responsive desktop, tablet, and mobile layouts
-- Keyboard-accessible mode controls, search controls, cards, and map markers
+- Keyboard-accessible mode controls, search controls, cards, detail drawer, and map markers
 - PawPath branded header and favicon
 
 ## Next proof-of-concept capabilities
 
 The remaining `v0.2 – Care Plan POC` work will add:
 
-- Facility-detail panels
-- Care-type and confidence indicators
 - Primary and backup facility selection
 - One locally saved active trip plan
 - Emergency Mode
@@ -76,7 +78,7 @@ See [Proof-of-Concept Scope](docs/POC_SCOPE.md) and [Roadmap](docs/ROADMAP.md).
 
 Phase 1 work is tracked in the [`v0.2 Care Plan POC` tracking issue](https://github.com/jeffthomasiii/pawpath/issues/13), with one issue for each feature package and its acceptance criteria.
 
-The next implementation task is [POC-02: Add facility detail and confidence states](https://github.com/jeffthomasiii/pawpath/issues/5).
+The next implementation task is [POC-03: Add primary and backup facility selection](https://github.com/jeffthomasiii/pawpath/issues/6).
 
 ## Product documentation
 
@@ -111,9 +113,9 @@ pawpath/
 ├── docs/                    # Product vision, POC scope, roadmap, backlog, and demo documentation
 ├── index.html               # Semantic application layout
 ├── styles.css               # Core responsive design system and components
-├── site-fixes.css           # Map, brand, and mode-layout enhancements
+├── site-fixes.css           # Map, brand, mode, and facility-detail enhancements
 ├── leaflet-local.css        # Locally hosted Leaflet layout styles
-├── app.js                   # Modes, map, geocoding, clinic search, filters, and UI state
+├── app.js                   # Modes, map, facility classification, detail rendering, search, filters, and UI state
 ├── map-layout-fix.js        # Defensive Leaflet resize handling
 └── README.md                # Project overview
 ```

--- a/app.js
+++ b/app.js
@@ -34,6 +34,32 @@ const MODE_CONTENT = {
   },
 };
 
+const CARE_TYPE_LABELS = {
+  emergency: "Emergency care",
+  urgent: "Urgent care",
+  routine: "Routine veterinary care",
+  unknown: "Care type unknown",
+};
+
+const CONFIDENCE_CONTENT = {
+  "demo-verified": {
+    label: "Demo verified",
+    explanation: "This demonstration record was manually reviewed on the date shown in its source notes.",
+  },
+  "source-listed": {
+    label: "Source listed",
+    explanation: "This information is shown as supplied by the listed data source. Contact the facility to confirm current services and availability.",
+  },
+  "likely-emergency": {
+    label: "Likely emergency",
+    explanation: "Emergency or urgent capability is inferred from the facility name or listing details and has not been independently verified by PawPath.",
+  },
+  "needs-confirmation": {
+    label: "Needs confirmation",
+    explanation: "Important listing details are missing or uncertain. Call the facility before relying on it for your trip plan.",
+  },
+};
+
 let map;
 let markerLayer;
 let clinics = [];
@@ -41,6 +67,7 @@ let activeFilter = "all";
 let activeMode = "plan";
 let currentSearchLabel = DEFAULT_LOCATION.label;
 let selectedClinicId = null;
+let lastDetailTrigger = null;
 const markersById = new Map();
 
 const elements = {};
@@ -79,6 +106,22 @@ function cacheElements() {
   elements.emptyTemplate = document.getElementById("empty-state-template");
   elements.filterButtons = [...document.querySelectorAll("[data-filter]")];
   elements.currentYear = document.getElementById("current-year");
+  elements.facilityDetail = document.getElementById("facility-detail");
+  elements.facilityDetailClose = document.getElementById("facility-detail-close");
+  elements.detailTitle = document.getElementById("facility-detail-title");
+  elements.detailCareType = document.getElementById("detail-care-type");
+  elements.detailConfidence = document.getElementById("detail-confidence");
+  elements.detailConfidenceExplanation = document.getElementById("detail-confidence-explanation");
+  elements.detailAddress = document.getElementById("detail-address");
+  elements.detailDistance = document.getElementById("detail-distance");
+  elements.detailPhone = document.getElementById("detail-phone");
+  elements.detailHours = document.getElementById("detail-hours");
+  elements.detailWebsiteValue = document.getElementById("detail-website-value");
+  elements.detailSource = document.getElementById("detail-source");
+  elements.detailSourceNotes = document.getElementById("detail-source-notes");
+  elements.detailCall = document.getElementById("detail-call");
+  elements.detailDirections = document.getElementById("detail-directions");
+  elements.detailWebsite = document.getElementById("detail-website");
 }
 
 function initializeMap() {
@@ -101,6 +144,11 @@ function initializeMap() {
 function bindEvents() {
   elements.searchForm.addEventListener("submit", handleSearchSubmit);
   elements.locationButton.addEventListener("click", handleGeolocation);
+  elements.facilityDetailClose.addEventListener("click", closeFacilityDetail);
+  elements.facilityDetail.addEventListener("click", (event) => {
+    if (event.target === elements.facilityDetail) closeFacilityDetail();
+  });
+  elements.facilityDetail.addEventListener("close", restoreDetailFocus);
 
   elements.modeButtons.forEach((button, index) => {
     button.addEventListener("click", () => setMode(button.dataset.mode, true));
@@ -317,7 +365,13 @@ function normalizeClinic(item, searchCenter) {
   const address = formatAddress(tags);
   const phone = tags.phone || tags["contact:phone"] || "";
   const website = normalizeWebsite(tags.website || tags["contact:website"] || "");
-  const emergency = isEmergencyClinic(tags, name);
+  const hours = tags.opening_hours || "";
+  const careType = classifyCareType(tags, name);
+  const confidence = classifyConfidence(tags, name, careType, phone, address);
+  const emergency = careType === "emergency" || careType === "urgent";
+  const source = "OpenStreetMap";
+  const sourceUrl = `https://www.openstreetmap.org/${item.type}/${item.id}`;
+  const sourceNotes = buildSourceNotes(confidence, careType);
 
   return {
     id: `${item.type}-${item.id}`,
@@ -325,7 +379,13 @@ function normalizeClinic(item, searchCenter) {
     address,
     phone,
     website,
+    hours,
+    careType,
+    confidence,
     emergency,
+    source,
+    sourceUrl,
+    sourceNotes,
     lat,
     lng,
     distanceMiles: haversineMiles(searchCenter.lat, searchCenter.lng, lat, lng),
@@ -343,9 +403,41 @@ function normalizeWebsite(value) {
   return /^https?:\/\//i.test(value) ? value : `https://${value}`;
 }
 
-function isEmergencyClinic(tags, name) {
-  const combined = `${name} ${tags.emergency || ""} ${tags.opening_hours || ""}`.toLowerCase();
-  return tags.emergency === "yes" || /emergency|24 hour|24-hour|urgent/.test(combined);
+function classifyCareType(tags, name) {
+  const normalizedName = name.toLowerCase();
+  const emergencyTag = String(tags.emergency || "").toLowerCase();
+  const speciality = String(tags["healthcare:speciality"] || "").toLowerCase();
+
+  if (emergencyTag === "yes" || speciality.includes("emergency")) return "emergency";
+  if (/urgent/.test(normalizedName)) return "urgent";
+  if (/emergency|24 hour|24-hour|24\/7/.test(normalizedName)) return "emergency";
+  if (tags.amenity === "veterinary") return "routine";
+  return "unknown";
+}
+
+function classifyConfidence(tags, name, careType, phone, address) {
+  const normalizedName = name.toLowerCase();
+  const emergencyTag = String(tags.emergency || "").toLowerCase();
+  const speciality = String(tags["healthcare:speciality"] || "").toLowerCase();
+  const hasExplicitEmergencySignal = emergencyTag === "yes" || speciality.includes("emergency");
+  const hasInferredEmergencySignal = /emergency|urgent|24 hour|24-hour|24\/7/.test(normalizedName);
+  const missingImportantDetails = !phone || address.startsWith("Address not listed");
+
+  if ((careType === "emergency" || careType === "urgent") && !hasExplicitEmergencySignal && hasInferredEmergencySignal) {
+    return "likely-emergency";
+  }
+  if (missingImportantDetails) return "needs-confirmation";
+  return "source-listed";
+}
+
+function buildSourceNotes(confidence, careType) {
+  if (confidence === "likely-emergency") {
+    return `The ${CARE_TYPE_LABELS[careType].toLowerCase()} classification is inferred from the listing name or source details. Confirm emergency capability, hours, and availability by phone.`;
+  }
+  if (confidence === "needs-confirmation") {
+    return "This OpenStreetMap listing is missing important contact or address details. Use the source link and call ahead before adding it to a care plan.";
+  }
+  return "Facility information is displayed from OpenStreetMap. PawPath has not independently verified current hours, availability, or treatment capabilities.";
 }
 
 function renderClinics() {
@@ -402,7 +494,7 @@ function createMarker(clinic) {
     <span>${escapeHtml(clinic.address)}</span>
   `);
 
-  marker.on("click", () => selectClinic(clinic.id, false));
+  marker.on("click", () => selectClinic(clinic.id, false, true, document.activeElement));
   return marker;
 }
 
@@ -411,7 +503,7 @@ function createClinicCard(clinic) {
   card.className = "clinic-card";
   card.tabIndex = 0;
   card.dataset.clinicId = clinic.id;
-  card.setAttribute("aria-label", `View ${clinic.name} on the map`);
+  card.setAttribute("aria-label", `View details for ${clinic.name}`);
 
   const directionsUrl = `https://www.google.com/maps/dir/?api=1&destination=${clinic.lat},${clinic.lng}`;
 
@@ -422,7 +514,7 @@ function createClinicCard(clinic) {
         <p>${escapeHtml(clinic.address)}</p>
       </div>
       <span class="care-badge${clinic.emergency ? " is-emergency" : ""}">
-        ${clinic.emergency ? "Emergency" : "Veterinary"}
+        ${escapeHtml(CARE_TYPE_LABELS[clinic.careType])}
       </span>
     </div>
     <div class="card-meta">
@@ -431,27 +523,27 @@ function createClinicCard(clinic) {
       ${clinic.website ? `<a href="${escapeAttribute(clinic.website)}" target="_blank" rel="noopener noreferrer">Website</a>` : ""}
     </div>
     <div class="card-actions">
-      <span>${clinic.emergency ? "Emergency service indicated" : "Call to confirm services"}</span>
+      <span>${escapeHtml(CONFIDENCE_CONTENT[clinic.confidence].label)} · View details</span>
       <a class="directions-link" href="${directionsUrl}" target="_blank" rel="noopener noreferrer">Directions ↗</a>
     </div>
   `;
 
   card.addEventListener("click", (event) => {
     if (event.target.closest("a")) return;
-    selectClinic(clinic.id, true);
+    selectClinic(clinic.id, true, true, card);
   });
 
   card.addEventListener("keydown", (event) => {
     if (event.key === "Enter" || event.key === " ") {
       event.preventDefault();
-      selectClinic(clinic.id, true);
+      selectClinic(clinic.id, true, true, card);
     }
   });
 
   return card;
 }
 
-function selectClinic(id, focusMap) {
+function selectClinic(id, focusMap, openDetail = true, triggerElement = null) {
   selectedClinicId = id;
   document.querySelectorAll(".clinic-card").forEach((card) => {
     card.classList.toggle("is-selected", card.dataset.clinicId === id);
@@ -468,6 +560,77 @@ function selectClinic(id, focusMap) {
 
   const card = document.querySelector(`[data-clinic-id="${CSS.escape(id)}"]`);
   card?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+
+  if (openDetail) {
+    openFacilityDetail(clinic, triggerElement || card || document.activeElement);
+  }
+}
+
+function openFacilityDetail(clinic, triggerElement) {
+  const confidenceContent = CONFIDENCE_CONTENT[clinic.confidence] || CONFIDENCE_CONTENT["needs-confirmation"];
+  lastDetailTrigger = triggerElement instanceof HTMLElement ? triggerElement : null;
+
+  elements.detailTitle.textContent = clinic.name;
+  elements.detailCareType.textContent = CARE_TYPE_LABELS[clinic.careType] || CARE_TYPE_LABELS.unknown;
+  elements.detailCareType.dataset.careType = clinic.careType;
+  elements.detailConfidence.textContent = confidenceContent.label;
+  elements.detailConfidence.dataset.confidence = clinic.confidence;
+  elements.detailConfidenceExplanation.textContent = confidenceContent.explanation;
+  elements.detailAddress.textContent = clinic.address || "Not listed";
+  elements.detailDistance.textContent = Number.isFinite(clinic.distanceMiles)
+    ? `${clinic.distanceMiles.toFixed(1)} miles from the search location`
+    : "Not available";
+  elements.detailPhone.textContent = clinic.phone || "Not listed";
+  elements.detailHours.textContent = clinic.hours || "Not listed — call to confirm";
+  elements.detailWebsiteValue.textContent = clinic.website ? getDisplayHostname(clinic.website) : "Not listed";
+  elements.detailSource.innerHTML = clinic.sourceUrl
+    ? `<a href="${escapeAttribute(clinic.sourceUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(clinic.source)} listing ↗</a>`
+    : escapeHtml(clinic.source || "Source not listed");
+  elements.detailSourceNotes.textContent = clinic.sourceNotes;
+
+  const directionsUrl = `https://www.google.com/maps/dir/?api=1&destination=${clinic.lat},${clinic.lng}`;
+  elements.detailDirections.href = directionsUrl;
+  configureOptionalAction(elements.detailCall, clinic.phone ? `tel:${normalizePhoneHref(clinic.phone)}` : "", "Call facility");
+  configureOptionalAction(elements.detailWebsite, clinic.website, "Website ↗");
+
+  if (!elements.facilityDetail.open) {
+    elements.facilityDetail.showModal();
+  }
+  requestAnimationFrame(() => elements.facilityDetailClose.focus());
+}
+
+function configureOptionalAction(element, href, label) {
+  element.textContent = href ? label : `${label.replace(" ↗", "")} unavailable`;
+  element.classList.toggle("is-disabled", !href);
+  element.setAttribute("aria-disabled", String(!href));
+  if (href) {
+    element.href = href;
+    element.removeAttribute("tabindex");
+  } else {
+    element.removeAttribute("href");
+    element.setAttribute("tabindex", "-1");
+  }
+}
+
+function closeFacilityDetail() {
+  if (elements.facilityDetail.open) elements.facilityDetail.close();
+}
+
+function restoreDetailFocus() {
+  if (lastDetailTrigger?.isConnected) lastDetailTrigger.focus();
+  lastDetailTrigger = null;
+}
+
+function normalizePhoneHref(phone) {
+  return phone.replace(/[^+\d]/g, "");
+}
+
+function getDisplayHostname(website) {
+  try {
+    return new URL(website).hostname.replace(/^www\./, "");
+  } catch {
+    return website;
+  }
 }
 
 function resetFilters() {

--- a/index.html
+++ b/index.html
@@ -114,6 +114,66 @@
       </section>
     </main>
 
+    <dialog id="facility-detail" class="facility-detail" aria-labelledby="facility-detail-title">
+      <div class="facility-detail-shell">
+        <header class="facility-detail-header">
+          <div>
+            <p class="eyebrow">Facility details</p>
+            <h2 id="facility-detail-title">Veterinary facility</h2>
+          </div>
+          <button id="facility-detail-close" class="icon-button" type="button" aria-label="Close facility details">×</button>
+        </header>
+
+        <div class="facility-detail-badges" aria-label="Facility classification">
+          <span id="detail-care-type" class="detail-badge">Care type unknown</span>
+          <span id="detail-confidence" class="detail-badge detail-confidence">Needs confirmation</span>
+        </div>
+
+        <p id="detail-confidence-explanation" class="confidence-explanation"></p>
+
+        <dl class="facility-facts">
+          <div>
+            <dt>Address</dt>
+            <dd id="detail-address">Not listed</dd>
+          </div>
+          <div>
+            <dt>Distance</dt>
+            <dd id="detail-distance">Not available</dd>
+          </div>
+          <div>
+            <dt>Phone</dt>
+            <dd id="detail-phone">Not listed</dd>
+          </div>
+          <div>
+            <dt>Hours</dt>
+            <dd id="detail-hours">Not listed</dd>
+          </div>
+          <div>
+            <dt>Website</dt>
+            <dd id="detail-website-value">Not listed</dd>
+          </div>
+          <div>
+            <dt>Data source</dt>
+            <dd id="detail-source">OpenStreetMap</dd>
+          </div>
+        </dl>
+
+        <section class="source-disclosure" aria-labelledby="source-disclosure-title">
+          <h3 id="source-disclosure-title">How to use this information</h3>
+          <p id="detail-source-notes"></p>
+          <p class="call-ahead-note">
+            <strong>Call ahead:</strong> PawPath does not guarantee that a facility is open, available, or able to treat a specific pet or condition.
+          </p>
+        </section>
+
+        <div class="facility-detail-actions">
+          <a id="detail-call" class="button button-primary" href="#">Call facility</a>
+          <a id="detail-directions" class="button detail-action-secondary" href="#" target="_blank" rel="noopener noreferrer">Directions ↗</a>
+          <a id="detail-website" class="button detail-action-secondary" href="#" target="_blank" rel="noopener noreferrer">Website ↗</a>
+        </div>
+      </div>
+    </dialog>
+
     <footer class="site-footer">
       <p>Built for campers, travelers, and the pets who come along.</p>
       <p>© <span id="current-year"></span> PawPath</p>

--- a/site-fixes.css
+++ b/site-fixes.css
@@ -235,3 +235,282 @@
     display: none;
   }
 }
+
+/* Facility detail drawer and transparent confidence presentation. */
+.facility-detail {
+  width: min(520px, calc(100vw - 32px));
+  max-width: none;
+  max-height: calc(100vh - 32px);
+  margin: 16px 16px 16px auto;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  background: var(--white);
+  color: var(--ink-900);
+  box-shadow: -18px 0 60px rgba(16, 45, 38, 0.24);
+}
+
+.facility-detail::backdrop {
+  background: rgba(8, 25, 21, 0.54);
+  backdrop-filter: blur(3px);
+}
+
+.facility-detail[open] {
+  animation: detail-drawer-in 180ms ease-out;
+}
+
+@keyframes detail-drawer-in {
+  from {
+    opacity: 0;
+    transform: translateX(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+.facility-detail-shell {
+  display: flex;
+  max-height: calc(100vh - 34px);
+  flex-direction: column;
+  gap: 20px;
+  overflow-y: auto;
+  padding: 26px;
+}
+
+.facility-detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.facility-detail-header h2 {
+  margin: 0;
+  color: var(--forest-950);
+  font-size: clamp(1.45rem, 4vw, 2rem);
+  line-height: 1.1;
+  letter-spacing: -0.035em;
+}
+
+.icon-button {
+  display: grid;
+  flex: 0 0 auto;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 13px;
+  background: var(--sage-50);
+  color: var(--forest-900);
+  cursor: pointer;
+  font-size: 1.55rem;
+  line-height: 1;
+}
+
+.icon-button:hover {
+  background: var(--sage-100);
+}
+
+.icon-button:focus-visible {
+  outline: 3px solid rgba(216, 148, 63, 0.55);
+  outline-offset: 3px;
+}
+
+.facility-detail-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.detail-badge {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--sage-100);
+  color: var(--forest-800);
+  font-size: 0.76rem;
+  font-weight: 800;
+}
+
+.detail-badge[data-care-type="emergency"],
+.detail-badge[data-care-type="urgent"] {
+  border-color: #efc8c1;
+  background: #fae6e2;
+  color: var(--danger);
+}
+
+.detail-confidence[data-confidence="likely-emergency"] {
+  border-color: #eccd9e;
+  background: #fff2dc;
+  color: #81511c;
+}
+
+.detail-confidence[data-confidence="needs-confirmation"] {
+  border-color: #d8d0c1;
+  background: var(--sand-100);
+  color: var(--ink-700);
+}
+
+.detail-confidence[data-confidence="demo-verified"] {
+  border-color: #b8d8c7;
+  background: #e7f5ec;
+  color: var(--forest-800);
+}
+
+.confidence-explanation {
+  margin: -8px 0 0;
+  color: var(--ink-700);
+  font-size: 0.91rem;
+}
+
+.facility-facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  margin: 0;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: var(--border);
+}
+
+.facility-facts > div {
+  min-width: 0;
+  padding: 14px;
+  background: var(--white);
+}
+
+.facility-facts dt {
+  margin-bottom: 4px;
+  color: var(--ink-500);
+  font-size: 0.69rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.facility-facts dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--ink-900);
+  font-size: 0.88rem;
+}
+
+.facility-facts a {
+  color: var(--forest-800);
+  font-weight: 750;
+}
+
+.source-disclosure {
+  padding: 17px;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: var(--sage-50);
+}
+
+.source-disclosure h3 {
+  margin: 0 0 7px;
+  color: var(--forest-950);
+  font-size: 1rem;
+}
+
+.source-disclosure p {
+  margin: 0;
+  color: var(--ink-700);
+  font-size: 0.86rem;
+}
+
+.source-disclosure .call-ahead-note {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.facility-detail-actions {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 9px;
+  position: sticky;
+  bottom: -26px;
+  margin: 0 -26px -26px;
+  padding: 16px 26px 24px;
+  border-top: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.96);
+  backdrop-filter: blur(12px);
+}
+
+.facility-detail-actions .button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  text-decoration: none;
+}
+
+.detail-action-secondary {
+  border-color: var(--border);
+  background: var(--white);
+  color: var(--forest-800);
+}
+
+.detail-action-secondary:hover {
+  border-color: var(--forest-700);
+  background: var(--sage-50);
+}
+
+.facility-detail-actions .is-disabled {
+  border-color: var(--border);
+  background: var(--sand-100);
+  color: var(--ink-500);
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+@media (max-width: 620px) {
+  .facility-detail {
+    width: 100vw;
+    max-height: 92vh;
+    margin: auto 0 0;
+    border-right: 0;
+    border-bottom: 0;
+    border-left: 0;
+    border-radius: 24px 24px 0 0;
+  }
+
+  .facility-detail[open] {
+    animation-name: detail-sheet-in;
+  }
+
+  @keyframes detail-sheet-in {
+    from {
+      opacity: 0;
+      transform: translateY(24px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .facility-detail-shell {
+    max-height: 92vh;
+    padding: 22px 18px;
+  }
+
+  .facility-facts {
+    grid-template-columns: 1fr;
+  }
+
+  .facility-detail-actions {
+    grid-template-columns: 1fr;
+    bottom: -22px;
+    margin: 0 -18px -22px;
+    padding: 14px 18px 20px;
+  }
+}


### PR DESCRIPTION
## What changed

- added a responsive facility-detail drawer on desktop and bottom sheet on mobile
- open the same detail experience from either a facility card or a Leaflet map marker
- added conservative facility classifications for emergency, urgent, routine, and unknown care
- added plain-language confidence states: Source listed, Likely emergency, Needs confirmation, and future-ready Demo verified
- show address, distance, phone, hours, website, and OpenStreetMap source information when available
- display missing information honestly instead of hiding it
- added Call, Directions, Website, source-link, and call-ahead guidance
- added keyboard focus management when opening and closing the detail view
- updated the README to reflect the completed capability and point to primary/backup selection next

## Validation

- `node --check app.js`
- parsed `index.html` with Python's HTML parser
- confirmed every JavaScript `getElementById` target exists in the HTML
- confirmed balanced CSS blocks
- reviewed the branch diff and key classification/detail functions against `main`
- branch is cleanly ahead of `main` and limited to `index.html`, `app.js`, `site-fixes.css`, and `README.md`

The repository has no automated build or browser-test suite, so live API behavior and visual layout still require a deployed browser check after merge.

Closes #5