### PR TITLE
Add primary and backup facility selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ PawPath is a mobile-friendly web application for campers, RV travelers, road-tri
 
 [Open PawPath](https://jeffthomasiii.github.io/pawpath/)
 
-The proof of concept now presents two distinct workflows: **Plan a Trip** for destination-based preparation and **Find Care Now** for immediate nearby-care access. Selecting a result opens a facility-detail view with conservative care classification, confidence explanations, source disclosure, and call-ahead guidance. Upcoming increments will add primary and backup selection, saved care plans, Emergency Mode, and a printable emergency card.
+The proof of concept now presents two distinct workflows: **Plan a Trip** for destination-based preparation and **Find Care Now** for immediate nearby-care access. Users can review facility details and confidence information, then choose a Primary emergency or urgent-care option and a distinct Backup facility for the current session. Upcoming increments will save the full trip care plan, add Emergency Mode, and create a printable emergency card.
 
 ## Why PawPath?
 
@@ -52,22 +52,25 @@ Use the current location to prioritize likely emergency-care options and quickly
 - Classify facilities conservatively as emergency, urgent, routine, or unknown
 - Show confidence states and plain-language explanations without relying only on color
 - Display missing information, OpenStreetMap source links, and call-ahead guidance honestly
+- Select one emergency or urgent-care facility as the Primary option
+- Select a distinct facility as the Backup option
+- Replace, move, view, or remove Primary and Backup selections during the current session
+- Show selected roles in the care-plan summary, facility cards, map markers, and facility details
 - Search by U.S. city, state, or ZIP code
 - Use browser geolocation to search near the current position
 - View veterinary clinics on an interactive Leaflet map
 - Filter results between all care, emergency, and routine clinics
-- Select a clinic card to center and open its map marker
 - Open driving directions without embedding a paid map service
 - Responsive desktop, tablet, and mobile layouts
-- Keyboard-accessible mode controls, search controls, cards, detail drawer, and map markers
+- Keyboard-accessible mode controls, search controls, cards, selections, detail drawer, and map markers
 - PawPath branded header and favicon
 
 ## Next proof-of-concept capabilities
 
 The remaining `v0.2 – Care Plan POC` work will add:
 
-- Primary and backup facility selection
 - One locally saved active trip plan
+- A persistent saved-plan summary
 - Emergency Mode
 - Curated demonstration data
 - Printable emergency card
@@ -78,7 +81,7 @@ See [Proof-of-Concept Scope](docs/POC_SCOPE.md) and [Roadmap](docs/ROADMAP.md).
 
 Phase 1 work is tracked in the [`v0.2 Care Plan POC` tracking issue](https://github.com/jeffthomasiii/pawpath/issues/13), with one issue for each feature package and its acceptance criteria.
 
-The next implementation task is [POC-03: Add primary and backup facility selection](https://github.com/jeffthomasiii/pawpath/issues/6).
+The next implementation task is [POC-04: Build and persist one active trip care plan](https://github.com/jeffthomasiii/pawpath/issues/7).
 
 ## Product documentation
 
@@ -114,8 +117,10 @@ pawpath/
 ├── index.html               # Semantic application layout
 ├── styles.css               # Core responsive design system and components
 ├── site-fixes.css           # Map, brand, mode, and facility-detail enhancements
+├── selection.css            # Primary and Backup selection components
 ├── leaflet-local.css        # Locally hosted Leaflet layout styles
 ├── app.js                   # Modes, map, facility classification, detail rendering, search, filters, and UI state
+├── selection.js             # Session-based Primary and Backup care-plan selection
 ├── map-layout-fix.js        # Defensive Leaflet resize handling
 └── README.md                # Project overview
 ```
@@ -155,7 +160,7 @@ PawPath is not a veterinary diagnosis or medical-triage service. It does not gua
 
 ## Privacy
 
-Location information is used in the browser to perform the requested nearby search. PawPath does not currently maintain a backend or store the user’s location. The first saved-plan implementation is intended to remain on the user’s device through browser `localStorage`.
+Location information is used in the browser to perform the requested nearby search. PawPath does not currently maintain a backend or store the user’s location. The next saved-plan implementation is intended to remain on the user’s device through browser `localStorage`.
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="leaflet-local.css" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="stylesheet" href="site-fixes.css" />
+    <link rel="stylesheet" href="selection.css" />
   </head>
 
   <body>
@@ -86,6 +87,39 @@
         <p id="mode-status" class="sr-only" aria-live="polite"></p>
       </section>
 
+      <section id="care-plan-selection" class="care-plan-selection" aria-labelledby="care-plan-selection-title">
+        <div class="care-plan-selection-heading">
+          <div>
+            <p class="eyebrow">Your care-plan choices</p>
+            <h2 id="care-plan-selection-title">Choose a primary and backup facility.</h2>
+          </div>
+          <p>Select a likely emergency or urgent-care facility first, then choose a distinct backup option.</p>
+        </div>
+
+        <div class="selection-slots">
+          <article id="primary-selection-slot" class="selection-slot" aria-labelledby="primary-selection-label">
+            <span id="primary-selection-label" class="selection-role-label is-primary">Primary</span>
+            <h3 id="primary-selection-name">No primary selected</h3>
+            <p id="primary-selection-meta">Choose a likely emergency or urgent-care facility from the map results.</p>
+            <div class="selection-slot-actions">
+              <button id="primary-selection-view" class="text-button" type="button" hidden>View details</button>
+              <button id="primary-selection-remove" class="text-button is-destructive" type="button" hidden>Remove</button>
+            </div>
+          </article>
+
+          <article id="backup-selection-slot" class="selection-slot" aria-labelledby="backup-selection-label">
+            <span id="backup-selection-label" class="selection-role-label is-backup">Backup</span>
+            <h3 id="backup-selection-name">No backup selected</h3>
+            <p id="backup-selection-meta">Choose a distinct backup facility in case the primary option is unavailable.</p>
+            <div class="selection-slot-actions">
+              <button id="backup-selection-view" class="text-button" type="button" hidden>View details</button>
+              <button id="backup-selection-remove" class="text-button is-destructive" type="button" hidden>Remove</button>
+            </div>
+          </article>
+        </div>
+        <p id="selection-status" class="sr-only" aria-live="polite"></p>
+      </section>
+
       <section class="discovery-layout" aria-label="Veterinary clinic finder">
         <aside class="results-panel" aria-labelledby="results-title">
           <div class="results-heading">
@@ -130,6 +164,20 @@
         </div>
 
         <p id="detail-confidence-explanation" class="confidence-explanation"></p>
+
+        <section class="facility-plan-selection" aria-labelledby="facility-plan-selection-title">
+          <div>
+            <h3 id="facility-plan-selection-title">Add to your trip care plan</h3>
+            <p id="detail-role-status">This facility has not been added to the care plan yet.</p>
+          </div>
+          <div class="facility-plan-buttons">
+            <button id="select-primary" class="plan-role-button is-primary" type="button">Select as Primary</button>
+            <button id="select-backup" class="plan-role-button is-backup" type="button">Select as Backup</button>
+          </div>
+          <p id="detail-plan-message" class="detail-plan-message">
+            Primary and Backup must be different facilities. You can replace or remove either choice at any time.
+          </p>
+        </section>
 
         <dl class="facility-facts">
           <div>
@@ -189,6 +237,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js" defer></script>
     <script src="app.js" defer></script>
+    <script src="selection.js" defer></script>
     <script src="map-layout-fix.js" defer></script>
   </body>
 </html>

--- a/selection.css
+++ b/selection.css
@@ -1,0 +1,257 @@
+/* Session-based Primary and Backup facility selection. */
+
+.care-plan-selection {
+  display: grid;
+  gap: 18px;
+  margin-top: 24px;
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--white);
+  box-shadow: var(--shadow-sm);
+}
+
+.care-plan-selection-heading {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 28px;
+}
+
+.care-plan-selection-heading h2 {
+  margin: 0;
+  color: var(--forest-950);
+  font-size: clamp(1.35rem, 3vw, 1.85rem);
+  letter-spacing: -0.035em;
+}
+
+.care-plan-selection-heading > p {
+  max-width: 500px;
+  margin: 0;
+  color: var(--ink-500);
+  font-size: 0.88rem;
+}
+
+.selection-slots {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.selection-slot {
+  position: relative;
+  display: grid;
+  align-content: start;
+  gap: 7px;
+  min-height: 150px;
+  padding: 18px;
+  border: 1px dashed #bfcac4;
+  border-radius: var(--radius-md);
+  background: var(--sage-50);
+}
+
+.selection-slot.is-filled {
+  border-style: solid;
+  background: var(--white);
+  box-shadow: 0 10px 28px rgba(16, 45, 38, 0.07);
+}
+
+.selection-slot.is-primary {
+  border-color: #d8a057;
+  background: #fffaf1;
+}
+
+.selection-slot.is-backup {
+  border-color: #85ad9b;
+  background: #f4faf6;
+}
+
+.selection-role-label,
+.card-plan-role {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  gap: 7px;
+  min-height: 27px;
+  padding: 4px 9px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 850;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.selection-role-label.is-primary,
+.card-plan-role.is-primary {
+  background: #f7dfb8;
+  color: #6f4515;
+}
+
+.selection-role-label.is-backup,
+.card-plan-role.is-backup {
+  background: #dceee4;
+  color: var(--forest-800);
+}
+
+.selection-slot h3 {
+  margin: 4px 0 0;
+  color: var(--forest-950);
+  font-size: 1.05rem;
+}
+
+.selection-slot > p {
+  margin: 0;
+  color: var(--ink-500);
+  font-size: 0.84rem;
+}
+
+.selection-slot-actions {
+  display: flex;
+  gap: 14px;
+  margin-top: auto;
+  padding-top: 10px;
+}
+
+.text-button {
+  min-height: 36px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--forest-800);
+  cursor: pointer;
+  font-weight: 800;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.text-button.is-destructive {
+  color: var(--danger);
+}
+
+.text-button:focus-visible,
+.plan-role-button:focus-visible {
+  outline: 3px solid rgba(216, 148, 63, 0.55);
+  outline-offset: 3px;
+}
+
+.card-plan-role {
+  margin-top: -2px;
+}
+
+.card-plan-role span {
+  display: grid;
+  width: 18px;
+  height: 18px;
+  place-items: center;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.72);
+  font-size: 0.64rem;
+}
+
+.custom-marker.is-primary {
+  background: var(--amber-500);
+  color: var(--forest-950);
+}
+
+.custom-marker.is-backup {
+  background: var(--forest-700);
+  color: var(--white);
+}
+
+.facility-plan-selection {
+  display: grid;
+  gap: 12px;
+  padding: 17px;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: var(--sand-50);
+}
+
+.facility-plan-selection h3 {
+  margin: 0 0 4px;
+  color: var(--forest-950);
+  font-size: 1rem;
+}
+
+.facility-plan-selection p {
+  margin: 0;
+  color: var(--ink-700);
+  font-size: 0.84rem;
+}
+
+.facility-plan-buttons {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 9px;
+}
+
+.plan-role-button {
+  min-height: 46px;
+  padding: 9px 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--white);
+  color: var(--forest-900);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 850;
+}
+
+.plan-role-button.is-primary {
+  border-color: #d8a057;
+}
+
+.plan-role-button.is-backup {
+  border-color: #85ad9b;
+}
+
+.plan-role-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.plan-role-button.is-selected-role {
+  background: var(--forest-900);
+  color: var(--white);
+}
+
+.plan-role-button:disabled {
+  background: var(--sand-100);
+  color: var(--ink-500);
+  cursor: not-allowed;
+}
+
+.detail-plan-message {
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+
+.detail-plan-message.is-error {
+  color: var(--danger);
+  font-weight: 700;
+}
+
+@media (max-width: 780px) {
+  .care-plan-selection-heading {
+    align-items: start;
+    flex-direction: column;
+    gap: 8px;
+  }
+}
+
+@media (max-width: 620px) {
+  .care-plan-selection {
+    padding: 18px;
+    border-radius: 22px;
+  }
+
+  .selection-slots,
+  .facility-plan-buttons {
+    grid-template-columns: 1fr;
+  }
+
+  .selection-slot {
+    min-height: 136px;
+  }
+}

--- a/selection.js
+++ b/selection.js
@@ -1,0 +1,257 @@
+const planSelections = {
+  primary: null,
+  backup: null,
+};
+
+let currentSelectionClinic = null;
+let selectionElements = {};
+
+const originalCreateClinicCard = createClinicCard;
+const originalCreateMarker = createMarker;
+const originalOpenFacilityDetail = openFacilityDetail;
+const originalRenderClinics = renderClinics;
+
+createClinicCard = function createSelectionAwareClinicCard(clinic) {
+  const card = originalCreateClinicCard(clinic);
+  const role = getFacilityRole(clinic.id);
+
+  if (role) {
+    const roleBanner = document.createElement("div");
+    roleBanner.className = `card-plan-role is-${role}`;
+    roleBanner.innerHTML = `<span aria-hidden="true">${role === "primary" ? "P" : "B"}</span>${capitalize(role)} care-plan option`;
+    const header = card.querySelector(".clinic-card-header");
+    header?.insertAdjacentElement("afterend", roleBanner);
+  }
+
+  return card;
+};
+
+createMarker = function createSelectionAwareMarker(clinic) {
+  const marker = originalCreateMarker(clinic);
+  marker.setIcon(createPlanMarkerIcon(clinic));
+  return marker;
+};
+
+openFacilityDetail = function openSelectionAwareFacilityDetail(clinic, triggerElement) {
+  currentSelectionClinic = clinic;
+  originalOpenFacilityDetail(clinic, triggerElement);
+  updateDetailSelectionControls(clinic);
+};
+
+renderClinics = function renderSelectionAwareClinics(options = {}) {
+  const preserveView = Boolean(options.preserveView && map);
+  const currentCenter = preserveView ? map.getCenter() : null;
+  const currentZoom = preserveView ? map.getZoom() : null;
+
+  originalRenderClinics();
+
+  if (preserveView && currentCenter && Number.isFinite(currentZoom)) {
+    map.setView(currentCenter, currentZoom, { animate: false });
+  }
+};
+
+document.addEventListener("DOMContentLoaded", initializeFacilitySelections);
+
+function initializeFacilitySelections() {
+  selectionElements = {
+    summary: document.getElementById("care-plan-selection"),
+    primarySlot: document.getElementById("primary-selection-slot"),
+    primaryName: document.getElementById("primary-selection-name"),
+    primaryMeta: document.getElementById("primary-selection-meta"),
+    primaryView: document.getElementById("primary-selection-view"),
+    primaryRemove: document.getElementById("primary-selection-remove"),
+    backupSlot: document.getElementById("backup-selection-slot"),
+    backupName: document.getElementById("backup-selection-name"),
+    backupMeta: document.getElementById("backup-selection-meta"),
+    backupView: document.getElementById("backup-selection-view"),
+    backupRemove: document.getElementById("backup-selection-remove"),
+    selectionStatus: document.getElementById("selection-status"),
+    detailRoleStatus: document.getElementById("detail-role-status"),
+    detailPlanMessage: document.getElementById("detail-plan-message"),
+    selectPrimary: document.getElementById("select-primary"),
+    selectBackup: document.getElementById("select-backup"),
+  };
+
+  selectionElements.selectPrimary.addEventListener("click", () => handleRoleAction("primary"));
+  selectionElements.selectBackup.addEventListener("click", () => handleRoleAction("backup"));
+  selectionElements.primaryView.addEventListener("click", () => openSelectionFromSummary("primary"));
+  selectionElements.backupView.addEventListener("click", () => openSelectionFromSummary("backup"));
+  selectionElements.primaryRemove.addEventListener("click", () => removeFacilityRole("primary"));
+  selectionElements.backupRemove.addEventListener("click", () => removeFacilityRole("backup"));
+
+  renderSelectionSummary();
+}
+
+function createPlanMarkerIcon(clinic) {
+  const role = getFacilityRole(clinic.id);
+  const roleClass = role ? ` is-${role}` : "";
+  const markerLabel = role === "primary" ? "P" : role === "backup" ? "B" : "✚";
+
+  return L.divIcon({
+    className: "",
+    html: `<div class="custom-marker${clinic.emergency ? " is-emergency" : ""}${roleClass}"><span aria-hidden="true">${markerLabel}</span></div>`,
+    iconSize: [34, 34],
+    iconAnchor: [17, 34],
+    popupAnchor: [0, -32],
+  });
+}
+
+function handleRoleAction(role) {
+  const clinic = currentSelectionClinic;
+  if (!clinic) return;
+
+  const currentRole = getFacilityRole(clinic.id);
+  if (currentRole === role) {
+    removeFacilityRole(role);
+    return;
+  }
+
+  if (role === "primary" && !isPrimaryEligible(clinic)) {
+    const message = "Primary care-plan options must be listed as emergency or urgent care. This facility may still be used as the backup option.";
+    announceSelection(message, true);
+    return;
+  }
+
+  const oppositeRole = role === "primary" ? "backup" : "primary";
+  const oppositeSelection = planSelections[oppositeRole];
+  const existingSelection = planSelections[role];
+
+  if (oppositeSelection?.id === clinic.id) {
+    const shouldMove = window.confirm(
+      `${clinic.name} is currently your ${capitalize(oppositeRole)} option. Move it to ${capitalize(role)}?`
+    );
+    if (!shouldMove) return;
+    planSelections[oppositeRole] = null;
+  }
+
+  if (existingSelection && existingSelection.id !== clinic.id) {
+    const shouldReplace = window.confirm(
+      `Replace ${existingSelection.name} with ${clinic.name} as your ${capitalize(role)} option?`
+    );
+    if (!shouldReplace) return;
+  }
+
+  planSelections[role] = { ...clinic };
+  const action = existingSelection ? "replaced" : "selected";
+  refreshSelectionPresentation();
+  announceSelection(`${clinic.name} ${action} as your ${capitalize(role)} care-plan option.`);
+}
+
+function removeFacilityRole(role) {
+  const facility = planSelections[role];
+  if (!facility) return;
+
+  planSelections[role] = null;
+  refreshSelectionPresentation();
+  announceSelection(`${facility.name} removed as your ${capitalize(role)} care-plan option.`);
+}
+
+function refreshSelectionPresentation() {
+  renderSelectionSummary();
+  renderClinics({ preserveView: true });
+
+  if (currentSelectionClinic) {
+    updateDetailSelectionControls(currentSelectionClinic);
+    const replacementCard = document.querySelector(`[data-clinic-id="${CSS.escape(currentSelectionClinic.id)}"]`);
+    if (replacementCard) lastDetailTrigger = replacementCard;
+  }
+}
+
+function renderSelectionSummary() {
+  renderSelectionSlot("primary", planSelections.primary);
+  renderSelectionSlot("backup", planSelections.backup);
+
+  const hasSelection = Boolean(planSelections.primary || planSelections.backup);
+  selectionElements.summary.classList.toggle("has-selections", hasSelection);
+}
+
+function renderSelectionSlot(role, facility) {
+  const isPrimary = role === "primary";
+  const slot = isPrimary ? selectionElements.primarySlot : selectionElements.backupSlot;
+  const name = isPrimary ? selectionElements.primaryName : selectionElements.backupName;
+  const meta = isPrimary ? selectionElements.primaryMeta : selectionElements.backupMeta;
+  const viewButton = isPrimary ? selectionElements.primaryView : selectionElements.backupView;
+  const removeButton = isPrimary ? selectionElements.primaryRemove : selectionElements.backupRemove;
+
+  slot.classList.toggle("is-filled", Boolean(facility));
+  slot.classList.toggle(`is-${role}`, Boolean(facility));
+
+  if (!facility) {
+    name.textContent = `No ${role} selected`;
+    meta.textContent = isPrimary
+      ? "Choose a likely emergency or urgent-care facility from the map results."
+      : "Choose a distinct backup facility in case the primary option is unavailable.";
+    viewButton.hidden = true;
+    removeButton.hidden = true;
+    return;
+  }
+
+  name.textContent = facility.name;
+  meta.textContent = `${CARE_TYPE_LABELS[facility.careType] || CARE_TYPE_LABELS.unknown} · ${facility.distanceMiles.toFixed(1)} mi from search`;
+  viewButton.hidden = false;
+  removeButton.hidden = false;
+}
+
+function openSelectionFromSummary(role) {
+  const facility = planSelections[role];
+  if (!facility) return;
+
+  const trigger = role === "primary" ? selectionElements.primaryView : selectionElements.backupView;
+  openFacilityDetail(facility, trigger);
+}
+
+function updateDetailSelectionControls(clinic) {
+  const role = getFacilityRole(clinic.id);
+  const primaryEligible = isPrimaryEligible(clinic);
+
+  selectionElements.detailRoleStatus.textContent = role
+    ? `This facility is selected as your ${capitalize(role)} care-plan option.`
+    : "This facility has not been added to the care plan yet.";
+
+  configureRoleButton(selectionElements.selectPrimary, "primary", role, primaryEligible);
+  configureRoleButton(selectionElements.selectBackup, "backup", role, true);
+  selectionElements.detailPlanMessage.textContent = primaryEligible
+    ? "Primary and Backup must be different facilities. You can replace or remove either choice at any time."
+    : "This listing is not currently classified as emergency or urgent care, so it can be selected as Backup but not Primary.";
+  selectionElements.detailPlanMessage.classList.remove("is-error");
+}
+
+function configureRoleButton(button, targetRole, currentRole, enabled) {
+  const existing = planSelections[targetRole];
+  const targetLabel = capitalize(targetRole);
+
+  button.disabled = !enabled && currentRole !== targetRole;
+  button.classList.toggle("is-selected-role", currentRole === targetRole);
+
+  if (currentRole === targetRole) {
+    button.textContent = `Remove as ${targetLabel}`;
+  } else if (!enabled) {
+    button.textContent = `${targetLabel} requires emergency or urgent care`;
+  } else if (currentRole && currentRole !== targetRole) {
+    button.textContent = `Move to ${targetLabel}`;
+  } else if (existing) {
+    button.textContent = `Replace ${targetLabel}`;
+  } else {
+    button.textContent = `Select as ${targetLabel}`;
+  }
+}
+
+function announceSelection(message, isError = false) {
+  selectionElements.selectionStatus.textContent = message;
+  selectionElements.detailPlanMessage.textContent = message;
+  selectionElements.detailPlanMessage.classList.toggle("is-error", isError);
+}
+
+function getFacilityRole(id) {
+  if (planSelections.primary?.id === id) return "primary";
+  if (planSelections.backup?.id === id) return "backup";
+  return null;
+}
+
+function isPrimaryEligible(clinic) {
+  return clinic.careType === "emergency" || clinic.careType === "urgent";
+}
+
+function capitalize(value) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}


### PR DESCRIPTION
## What changed

- added a care-plan selection summary between the search workflow and the map
- added **Select as Primary** and **Select as Backup** actions to facility details
- limited Primary selections to listings classified as emergency or urgent care
- require Primary and Backup to be different facilities
- added explicit confirmation when moving a facility between roles or replacing an existing choice
- allow users to view, replace, move, or remove either selection
- keep selected facility snapshots available throughout the current browser session, including after additional searches
- show Primary and Backup roles on summary cards, result cards, map markers, and facility details
- added accessible status announcements and keyboard-operable actions
- isolated the feature in `selection.js` and `selection.css` to reduce risk to the existing map/search implementation
- updated the README and pointed the roadmap to the saved-care-plan increment

## Validation

- `node --check selection.js`
- parsed `index.html` with Python's HTML parser
- confirmed all `getElementById` references in `selection.js` exist in the HTML
- confirmed balanced CSS blocks
- reviewed the branch diff against `main`
- branch is cleanly ahead of `main` and does not modify the established map or facility-detail modules

The repository has no automated browser-test suite, so the deployed workflow still requires a visual and interaction check after merge.

Closes #6