### PR TITLE
Add nearest emergency-care fallback search

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ PawPath is a mobile-friendly web application for campers, RV travelers, road-tri
 
 [Open PawPath](https://jeffthomasiii.github.io/pawpath/)
 
-The proof of concept now presents two distinct workflows: **Plan a Trip** for destination-based preparation and **Find Care Now** for immediate nearby-care access. Users can review facility details and confidence information, then choose a Primary emergency or urgent-care option and a distinct Backup facility for the current session. Upcoming increments will save the full trip care plan, add Emergency Mode, and create a printable emergency card.
+The proof of concept now presents two distinct workflows: **Plan a Trip** for destination-based preparation and **Find Care Now** for immediate nearby-care access. Users can review facility details and confidence information, then choose a Primary emergency or urgent-care option and a distinct Backup facility for the current session. When the normal nearby search contains no emergency or urgent-care option, PawPath also checks a 30-mile fallback radius and adds the nearest qualifying listing. Upcoming increments will save the full trip care plan, add Emergency Mode, and create a printable emergency card.
 
 ## Why PawPath?
 
@@ -48,6 +48,7 @@ Use the current location to prioritize likely emergency-care options and quickly
 - Switch between Plan a Trip and Find Care Now modes
 - Use destination-focused search language and actions for trip preparation
 - Emphasize current-location access for immediate nearby-care searches
+- Search a 30-mile fallback radius for the nearest emergency or urgent-care option only when none appears in the normal nearby results
 - Open the same facility-detail experience from a result card or map marker
 - Classify facilities conservatively as emergency, urgent, routine, or unknown
 - Show confidence states and plain-language explanations without relying only on color
@@ -118,8 +119,10 @@ pawpath/
 ├── styles.css               # Core responsive design system and components
 ├── site-fixes.css           # Map, brand, mode, and facility-detail enhancements
 ├── selection.css            # Primary and Backup selection components
+├── emergency-fallback.css   # Extended emergency-result presentation
 ├── leaflet-local.css        # Locally hosted Leaflet layout styles
 ├── app.js                   # Modes, map, facility classification, detail rendering, search, filters, and UI state
+├── emergency-fallback.js    # Conditional 30-mile emergency and urgent-care fallback search
 ├── selection.js             # Session-based Primary and Backup care-plan selection
 ├── map-layout-fix.js        # Defensive Leaflet resize handling
 └── README.md                # Project overview

--- a/emergency-fallback.css
+++ b/emergency-fallback.css
@@ -1,0 +1,39 @@
+.clinic-card.is-extended-emergency {
+  border-color: rgba(163, 62, 50, 0.45);
+  background: linear-gradient(180deg, #fffaf8, var(--white));
+}
+
+.extended-emergency-note {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 11px;
+  border: 1px solid rgba(163, 62, 50, 0.18);
+  border-radius: 10px;
+  background: #fae6e2;
+  color: var(--danger);
+  font-size: 0.76rem;
+  line-height: 1.3;
+}
+
+.extended-emergency-note strong {
+  font-size: 0.78rem;
+}
+
+.extended-emergency-note span {
+  color: #75453f;
+  text-align: right;
+}
+
+@media (max-width: 460px) {
+  .extended-emergency-note {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .extended-emergency-note span {
+    text-align: left;
+  }
+}

--- a/emergency-fallback.js
+++ b/emergency-fallback.js
@@ -1,0 +1,115 @@
+const EMERGENCY_FALLBACK_RADIUS_METERS = 48280;
+const METERS_PER_MILE = 1609.344;
+const NORMAL_SEARCH_RADIUS_MILES = Math.round(SEARCH_RADIUS_METERS / METERS_PER_MILE);
+const EMERGENCY_FALLBACK_RADIUS_MILES = Math.round(EMERGENCY_FALLBACK_RADIUS_METERS / METERS_PER_MILE);
+
+const originalFetchVeterinaryClinicsForFallback = fetchVeterinaryClinics;
+const originalSearchNearbyForFallback = searchNearby;
+const originalCreateClinicCardForFallback = createClinicCard;
+
+let emergencyFallbackState = {
+  added: false,
+  facility: null,
+};
+
+MODE_CONTENT.plan.locationButton = "Use my location";
+
+fetchVeterinaryClinics = async function fetchVeterinaryClinicsWithEmergencyFallback(center) {
+  emergencyFallbackState = { added: false, facility: null };
+
+  const nearbyClinics = await originalFetchVeterinaryClinicsForFallback(center);
+  if (nearbyClinics.some(isEmergencyOrUrgentFacility)) return nearbyClinics;
+
+  try {
+    const fallbackCandidates = await fetchEmergencyFallbackCandidates(center);
+    const nearbyIds = new Set(nearbyClinics.map((clinic) => clinic.id));
+    const nearestFallback = fallbackCandidates
+      .filter((clinic) => !nearbyIds.has(clinic.id))
+      .filter((clinic) => clinic.distanceMiles <= EMERGENCY_FALLBACK_RADIUS_MILES)
+      .sort((a, b) => a.distanceMiles - b.distanceMiles)[0];
+
+    if (!nearestFallback) return nearbyClinics;
+
+    nearestFallback.isExtendedEmergencySearch = true;
+    nearestFallback.sourceNotes = `${nearestFallback.sourceNotes} PawPath included this facility because no emergency or urgent-care listing appeared within the normal ${NORMAL_SEARCH_RADIUS_MILES}-mile search area.`;
+    emergencyFallbackState = { added: true, facility: nearestFallback };
+
+    return [...nearbyClinics, nearestFallback].sort((a, b) => a.distanceMiles - b.distanceMiles);
+  } catch (error) {
+    console.warn("Extended emergency-care search failed:", error);
+    return nearbyClinics;
+  }
+};
+
+searchNearby = async function searchNearbyWithEmergencyFallback(center, label) {
+  await originalSearchNearbyForFallback(center, label);
+
+  if (!emergencyFallbackState.added || !emergencyFallbackState.facility) return;
+
+  const facility = emergencyFallbackState.facility;
+  setMessage(
+    `No emergency or urgent-care listing appeared within ${NORMAL_SEARCH_RADIUS_MILES} miles, so PawPath added the nearest likely option within ${EMERGENCY_FALLBACK_RADIUS_MILES} miles: ${facility.name} (${facility.distanceMiles.toFixed(1)} miles away). Call ahead to confirm services and availability.`
+  );
+};
+
+createClinicCard = function createClinicCardWithEmergencyFallback(clinic) {
+  const card = originalCreateClinicCardForFallback(clinic);
+
+  if (!clinic.isExtendedEmergencySearch) return card;
+
+  card.classList.add("is-extended-emergency");
+  const note = document.createElement("div");
+  note.className = "extended-emergency-note";
+  note.innerHTML = `
+    <strong>Nearest emergency option</strong>
+    <span>Expanded search · ${clinic.distanceMiles.toFixed(1)} mi away</span>
+  `;
+
+  const header = card.querySelector(".clinic-card-header");
+  header?.insertAdjacentElement("afterend", note);
+  return card;
+};
+
+async function fetchEmergencyFallbackCandidates(center) {
+  const emergencyNamePattern = "emergency|urgent|24[ -]?hour|24/7";
+  const query = `
+    [out:json][timeout:25];
+    (
+      node["amenity"="veterinary"]["emergency"="yes"](around:${EMERGENCY_FALLBACK_RADIUS_METERS},${center.lat},${center.lng});
+      way["amenity"="veterinary"]["emergency"="yes"](around:${EMERGENCY_FALLBACK_RADIUS_METERS},${center.lat},${center.lng});
+      relation["amenity"="veterinary"]["emergency"="yes"](around:${EMERGENCY_FALLBACK_RADIUS_METERS},${center.lat},${center.lng});
+      node["amenity"="veterinary"]["healthcare:speciality"~"emergency",i](around:${EMERGENCY_FALLBACK_RADIUS_METERS},${center.lat},${center.lng});
+      way["amenity"="veterinary"]["healthcare:speciality"~"emergency",i](around:${EMERGENCY_FALLBACK_RADIUS_METERS},${center.lat},${center.lng});
+      relation["amenity"="veterinary"]["healthcare:speciality"~"emergency",i](around:${EMERGENCY_FALLBACK_RADIUS_METERS},${center.lat},${center.lng});
+      node["amenity"="veterinary"]["name"~"${emergencyNamePattern}",i](around:${EMERGENCY_FALLBACK_RADIUS_METERS},${center.lat},${center.lng});
+      way["amenity"="veterinary"]["name"~"${emergencyNamePattern}",i](around:${EMERGENCY_FALLBACK_RADIUS_METERS},${center.lat},${center.lng});
+      relation["amenity"="veterinary"]["name"~"${emergencyNamePattern}",i](around:${EMERGENCY_FALLBACK_RADIUS_METERS},${center.lat},${center.lng});
+    );
+    out center tags;
+  `;
+
+  const response = await fetch(OVERPASS_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8" },
+    body: new URLSearchParams({ data: query }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Extended Overpass request failed with status ${response.status}`);
+  }
+
+  const data = await response.json();
+  const uniqueClinics = new Map();
+
+  data.elements.forEach((item) => {
+    const clinic = normalizeClinic(item, center);
+    if (!clinic || !isEmergencyOrUrgentFacility(clinic)) return;
+    uniqueClinics.set(clinic.id, clinic);
+  });
+
+  return [...uniqueClinics.values()].sort((a, b) => a.distanceMiles - b.distanceMiles);
+}
+
+function isEmergencyOrUrgentFacility(clinic) {
+  return clinic.careType === "emergency" || clinic.careType === "urgent";
+}

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <link rel="stylesheet" href="styles.css" />
     <link rel="stylesheet" href="site-fixes.css" />
     <link rel="stylesheet" href="selection.css" />
+    <link rel="stylesheet" href="emergency-fallback.css" />
   </head>
 
   <body>
@@ -76,7 +77,7 @@
             </button>
             <button class="button button-secondary" type="button" id="loc-btn">
               <span aria-hidden="true">◎</span>
-              <span id="location-button-label">Use current location instead</span>
+              <span id="location-button-label">Use my location</span>
             </button>
           </div>
           <p id="mode-guidance" class="mode-guidance">
@@ -237,6 +238,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet.js" defer></script>
     <script src="app.js" defer></script>
+    <script src="emergency-fallback.js" defer></script>
     <script src="selection.js" defer></script>
     <script src="map-layout-fix.js" defer></script>
   </body>


### PR DESCRIPTION
## What changed

- shortened the Plan a Trip location button from **Use current location instead** to **Use my location**
- kept the normal nearby veterinary search unchanged
- when the nearby results contain no emergency or urgent-care listing, run a targeted fallback search within 30 miles
- add only the nearest qualifying fallback facility rather than all distant results
- clearly label the added facility as the nearest emergency option from an expanded search
- include the fallback distance and an explicit call-ahead message
- preserve existing facility details, Primary/Backup selection, filters, markers, and map behavior
- document the fallback behavior and new module structure in the README

## Validation

- `node --check emergency-fallback.js`
- confirmed balanced CSS blocks
- reviewed the branch diff against `main`
- branch is cleanly ahead of `main` with changes limited to `index.html`, `README.md`, `emergency-fallback.js`, and `emergency-fallback.css`

The repository has no automated browser-test suite. The fallback still needs a deployed test from a location with no nearby emergency or urgent-care result.