### PR TITLE
Fix expanded emergency search labels

### DIFF
--- a/emergency-fallback.css
+++ b/emergency-fallback.css
@@ -1,3 +1,25 @@
+.expanded-emergency-search-notice {
+  display: grid;
+  gap: 3px;
+  margin: -4px 0 16px;
+  padding: 12px 14px;
+  border: 1px solid rgba(163, 62, 50, 0.24);
+  border-radius: 12px;
+  background: #fff4f1;
+  color: #75453f;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.expanded-emergency-search-notice[hidden] {
+  display: none;
+}
+
+.expanded-emergency-search-notice strong {
+  color: var(--danger);
+  font-size: 0.82rem;
+}
+
 .clinic-card.is-extended-emergency {
   border-color: rgba(163, 62, 50, 0.45);
   background: linear-gradient(180deg, #fffaf8, var(--white));
@@ -26,7 +48,16 @@
   text-align: right;
 }
 
+.custom-marker.is-expanded-emergency {
+  outline: 4px solid rgba(216, 148, 63, 0.48);
+  outline-offset: 3px;
+}
+
 @media (max-width: 460px) {
+  .expanded-emergency-search-notice {
+    margin-bottom: 12px;
+  }
+
   .extended-emergency-note {
     align-items: flex-start;
     flex-direction: column;

--- a/emergency-fallback.js
+++ b/emergency-fallback.js
@@ -6,7 +6,8 @@ const SEARCH_RADIUS_TOLERANCE_MILES = 0.35;
 
 const originalFetchVeterinaryClinicsForFallback = fetchVeterinaryClinics;
 const originalSearchNearbyForFallback = searchNearby;
-const originalRenderClinicsForFallback = renderClinics;
+let originalRenderClinicsForFallback = null;
+let emergencyFallbackRenderHookInstalled = false;
 
 let emergencyFallbackState = {
   added: false,
@@ -14,6 +15,7 @@ let emergencyFallbackState = {
 };
 
 MODE_CONTENT.plan.locationButton = "Use my location";
+document.addEventListener("DOMContentLoaded", installEmergencyFallbackRenderHook);
 
 fetchVeterinaryClinics = async function fetchVeterinaryClinicsWithEmergencyFallback(center) {
   emergencyFallbackState = { added: false, facility: null };
@@ -60,10 +62,16 @@ searchNearby = async function searchNearbyWithEmergencyFallback(center, label) {
   );
 };
 
-renderClinics = function renderClinicsWithEmergencyFallback(options = {}) {
-  originalRenderClinicsForFallback(options);
-  updateEmergencyFallbackPresentation();
-};
+function installEmergencyFallbackRenderHook() {
+  if (emergencyFallbackRenderHookInstalled) return;
+
+  originalRenderClinicsForFallback = renderClinics;
+  renderClinics = function renderClinicsWithEmergencyFallback(options = {}) {
+    originalRenderClinicsForFallback(options);
+    updateEmergencyFallbackPresentation();
+  };
+  emergencyFallbackRenderHookInstalled = true;
+}
 
 function updateEmergencyFallbackPresentation() {
   const notice = ensureExpandedSearchNotice();

--- a/emergency-fallback.js
+++ b/emergency-fallback.js
@@ -1,11 +1,12 @@
 const EMERGENCY_FALLBACK_RADIUS_METERS = 48280;
 const METERS_PER_MILE = 1609.344;
-const NORMAL_SEARCH_RADIUS_MILES = Math.round(SEARCH_RADIUS_METERS / METERS_PER_MILE);
-const EMERGENCY_FALLBACK_RADIUS_MILES = Math.round(EMERGENCY_FALLBACK_RADIUS_METERS / METERS_PER_MILE);
+const NORMAL_SEARCH_RADIUS_MILES = SEARCH_RADIUS_METERS / METERS_PER_MILE;
+const EMERGENCY_FALLBACK_RADIUS_MILES = EMERGENCY_FALLBACK_RADIUS_METERS / METERS_PER_MILE;
+const SEARCH_RADIUS_TOLERANCE_MILES = 0.35;
 
 const originalFetchVeterinaryClinicsForFallback = fetchVeterinaryClinics;
 const originalSearchNearbyForFallback = searchNearby;
-const originalCreateClinicCardForFallback = createClinicCard;
+const originalRenderClinicsForFallback = renderClinics;
 
 let emergencyFallbackState = {
   added: false,
@@ -17,7 +18,11 @@ MODE_CONTENT.plan.locationButton = "Use my location";
 fetchVeterinaryClinics = async function fetchVeterinaryClinicsWithEmergencyFallback(center) {
   emergencyFallbackState = { added: false, facility: null };
 
-  const nearbyClinics = await originalFetchVeterinaryClinicsForFallback(center);
+  const fetchedClinics = await originalFetchVeterinaryClinicsForFallback(center);
+  const nearbyClinics = fetchedClinics.filter(
+    (clinic) => clinic.distanceMiles <= NORMAL_SEARCH_RADIUS_MILES + SEARCH_RADIUS_TOLERANCE_MILES
+  );
+
   if (nearbyClinics.some(isEmergencyOrUrgentFacility)) return nearbyClinics;
 
   try {
@@ -25,13 +30,15 @@ fetchVeterinaryClinics = async function fetchVeterinaryClinicsWithEmergencyFallb
     const nearbyIds = new Set(nearbyClinics.map((clinic) => clinic.id));
     const nearestFallback = fallbackCandidates
       .filter((clinic) => !nearbyIds.has(clinic.id))
+      .filter((clinic) => clinic.distanceMiles > NORMAL_SEARCH_RADIUS_MILES)
       .filter((clinic) => clinic.distanceMiles <= EMERGENCY_FALLBACK_RADIUS_MILES)
       .sort((a, b) => a.distanceMiles - b.distanceMiles)[0];
 
     if (!nearestFallback) return nearbyClinics;
 
     nearestFallback.isExtendedEmergencySearch = true;
-    nearestFallback.sourceNotes = `${nearestFallback.sourceNotes} PawPath included this facility because no emergency or urgent-care listing appeared within the normal ${NORMAL_SEARCH_RADIUS_MILES}-mile search area.`;
+    nearestFallback.searchScope = "expanded-emergency";
+    nearestFallback.sourceNotes = `${nearestFallback.sourceNotes} PawPath included this facility because no emergency or urgent-care listing appeared within the normal ${NORMAL_SEARCH_RADIUS_MILES.toFixed(1)}-mile search area.`;
     emergencyFallbackState = { added: true, facility: nearestFallback };
 
     return [...nearbyClinics, nearestFallback].sort((a, b) => a.distanceMiles - b.distanceMiles);
@@ -43,32 +50,83 @@ fetchVeterinaryClinics = async function fetchVeterinaryClinicsWithEmergencyFallb
 
 searchNearby = async function searchNearbyWithEmergencyFallback(center, label) {
   await originalSearchNearbyForFallback(center, label);
+  updateEmergencyFallbackPresentation();
 
   if (!emergencyFallbackState.added || !emergencyFallbackState.facility) return;
 
   const facility = emergencyFallbackState.facility;
   setMessage(
-    `No emergency or urgent-care listing appeared within ${NORMAL_SEARCH_RADIUS_MILES} miles, so PawPath added the nearest likely option within ${EMERGENCY_FALLBACK_RADIUS_MILES} miles: ${facility.name} (${facility.distanceMiles.toFixed(1)} miles away). Call ahead to confirm services and availability.`
+    `No emergency or urgent-care listing appeared within ${NORMAL_SEARCH_RADIUS_MILES.toFixed(1)} miles, so PawPath added the nearest likely option within ${EMERGENCY_FALLBACK_RADIUS_MILES.toFixed(0)} miles: ${facility.name} (${facility.distanceMiles.toFixed(1)} miles away). Call ahead to confirm services and availability.`
   );
 };
 
-createClinicCard = function createClinicCardWithEmergencyFallback(clinic) {
-  const card = originalCreateClinicCardForFallback(clinic);
+renderClinics = function renderClinicsWithEmergencyFallback(options = {}) {
+  originalRenderClinicsForFallback(options);
+  updateEmergencyFallbackPresentation();
+};
 
-  if (!clinic.isExtendedEmergencySearch) return card;
+function updateEmergencyFallbackPresentation() {
+  const notice = ensureExpandedSearchNotice();
 
-  card.classList.add("is-extended-emergency");
-  const note = document.createElement("div");
-  note.className = "extended-emergency-note";
-  note.innerHTML = `
-    <strong>Nearest emergency option</strong>
-    <span>Expanded search · ${clinic.distanceMiles.toFixed(1)} mi away</span>
+  document.querySelectorAll(".extended-emergency-note").forEach((element) => element.remove());
+  document.querySelectorAll(".clinic-card.is-extended-emergency").forEach((element) => {
+    element.classList.remove("is-extended-emergency");
+  });
+  document.querySelectorAll(".custom-marker.is-expanded-emergency").forEach((element) => {
+    element.classList.remove("is-expanded-emergency");
+  });
+
+  if (!emergencyFallbackState.added || !emergencyFallbackState.facility) {
+    notice.hidden = true;
+    notice.innerHTML = "";
+    return;
+  }
+
+  const facility = emergencyFallbackState.facility;
+  notice.hidden = false;
+  notice.innerHTML = `
+    <strong>Expanded emergency search</strong>
+    <span>No emergency or urgent-care listing was found within ${NORMAL_SEARCH_RADIUS_MILES.toFixed(1)} miles. Showing the nearest likely option: ${escapeHtml(facility.name)}, ${facility.distanceMiles.toFixed(1)} miles away.</span>
   `;
 
-  const header = card.querySelector(".clinic-card-header");
-  header?.insertAdjacentElement("afterend", note);
-  return card;
-};
+  const card = document.querySelector(`[data-clinic-id="${CSS.escape(facility.id)}"]`);
+  if (card) {
+    card.classList.add("is-extended-emergency");
+    card.setAttribute(
+      "aria-label",
+      `Nearest emergency option from an expanded search. View details for ${facility.name}`
+    );
+
+    const note = document.createElement("div");
+    note.className = "extended-emergency-note";
+    note.innerHTML = `
+      <strong>Nearest emergency option</strong>
+      <span>Expanded search · ${facility.distanceMiles.toFixed(1)} mi away</span>
+    `;
+
+    const header = card.querySelector(".clinic-card-header");
+    header?.insertAdjacentElement("afterend", note);
+  }
+
+  const marker = markersById.get(facility.id);
+  marker?.getElement()?.querySelector(".custom-marker")?.classList.add("is-expanded-emergency");
+}
+
+function ensureExpandedSearchNotice() {
+  let notice = document.getElementById("expanded-emergency-search-notice");
+  if (notice) return notice;
+
+  notice = document.createElement("div");
+  notice.id = "expanded-emergency-search-notice";
+  notice.className = "expanded-emergency-search-notice";
+  notice.setAttribute("role", "status");
+  notice.setAttribute("aria-live", "polite");
+  notice.hidden = true;
+
+  const filterRow = document.querySelector(".filter-row");
+  filterRow?.insertAdjacentElement("afterend", notice);
+  return notice;
+}
 
 async function fetchEmergencyFallbackCandidates(center) {
   const emergencyNamePattern = "emergency|urgent|24[ -]?hour|24/7";


### PR DESCRIPTION
## What changed

- enforce the normal nearby-search boundary before evaluating fallback results
- add only the single nearest emergency or urgent-care facility from the 30-mile fallback
- replace the fragile card-wrapper label with a post-render decoration step
- add a persistent **Expanded emergency search** notice above the results
- reapply the card label after searches, filters, and Primary/Backup selection rerenders
- add a visual ring to the expanded-search map marker
- use the exact normal radius in user-facing copy instead of rounding it down

## Validation

- `node --check emergency-fallback.js`
- confirmed balanced CSS blocks
- reviewed the branch diff against `main`
- changes are limited to `emergency-fallback.js` and `emergency-fallback.css`

The repository does not have an automated browser-test suite, so the deployed geolocation scenario still needs a browser check after GitHub Pages publishes the merge.