### PR TITLE
Build and persist one active trip care plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ PawPath is a mobile-friendly web application for campers, RV travelers, road-tri
 
 [Open PawPath](https://jeffthomasiii.github.io/pawpath/)
 
-The proof of concept now presents two distinct workflows: **Plan a Trip** for destination-based preparation and **Find Care Now** for immediate nearby-care access. Users can review facility details and confidence information, then choose a Primary emergency or urgent-care option and a distinct Backup facility for the current session. When the normal nearby search contains no emergency or urgent-care option, PawPath also checks a 30-mile fallback radius and adds the nearest qualifying listing. Upcoming increments will save the full trip care plan, add Emergency Mode, and create a printable emergency card.
+The proof of concept now presents two functionally distinct workflows. **Plan a Trip** lets users enter trip details, choose Primary and Backup facilities, and save one active care plan locally in the browser. **Find Care Now** hides the planning form and focuses on immediate nearby-care search. When the normal nearby search contains no emergency or urgent-care option, PawPath also checks a 30-mile fallback radius and either adds the nearest qualifying listing or clearly explains that OpenStreetMap could not identify one.
 
 ## Why PawPath?
 
@@ -37,15 +37,23 @@ PawPath is organized around two core experiences:
 
 ### Plan a Trip
 
-Search around a campground, destination, ZIP code, or overnight stop; review care options; choose a primary facility and backup; and save the essential details before leaving.
+Search around a campground, destination, ZIP code, or overnight stop; enter trip and pet details; choose a Primary facility and Backup; and save the essential information before leaving.
 
 ### Find Care Now
 
-Use the current location to prioritize likely emergency-care options and quickly access call, directions, backup, and saved pet-information actions.
+Use the current location to prioritize likely emergency-care options and quickly access call, directions, backup, and saved pet-information actions without showing the trip-planning form.
 
 ## Current capabilities
 
 - Switch between Plan a Trip and Find Care Now modes
+- Show a trip-plan editor only in Plan a Trip mode
+- Save one active care plan to browser `localStorage` using `pawpath.activeCarePlan.v1`
+- Store a trip name, destination, optional dates, pet name, owner phone, and one brief important note
+- Save and restore Primary and Backup facility snapshots after a full page refresh
+- Validate stored schema and fail safely when stored data is malformed or unsupported
+- Automatically update a saved plan when trip details or facility choices change
+- Clear the saved plan and selections with confirmation
+- Keep saved plan data entirely in the browser without an account or backend
 - Use destination-focused search language and actions for trip preparation
 - Emphasize current-location access for immediate nearby-care searches
 - Search a 30-mile fallback radius for the nearest emergency or urgent-care option only when none appears in the normal nearby results
@@ -55,7 +63,7 @@ Use the current location to prioritize likely emergency-care options and quickly
 - Display missing information, OpenStreetMap source links, and call-ahead guidance honestly
 - Select one emergency or urgent-care facility as the Primary option
 - Select a distinct facility as the Backup option
-- Replace, move, view, or remove Primary and Backup selections during the current session
+- Replace, move, view, or remove Primary and Backup selections
 - Show selected roles in the care-plan summary, facility cards, map markers, and facility details
 - Search by U.S. city, state, or ZIP code
 - Use browser geolocation to search near the current position
@@ -63,15 +71,14 @@ Use the current location to prioritize likely emergency-care options and quickly
 - Filter results between all care, emergency, and routine clinics
 - Open driving directions without embedding a paid map service
 - Responsive desktop, tablet, and mobile layouts
-- Keyboard-accessible mode controls, search controls, cards, selections, detail drawer, and map markers
+- Keyboard-accessible mode controls, search controls, cards, selections, forms, detail drawer, and map markers
 - PawPath branded header and favicon
 
 ## Next proof-of-concept capabilities
 
 The remaining `v0.2 – Care Plan POC` work will add:
 
-- One locally saved active trip plan
-- A persistent saved-plan summary
+- A persistent saved-plan summary optimized for quick review
 - Emergency Mode
 - Curated demonstration data
 - Printable emergency card
@@ -82,7 +89,7 @@ See [Proof-of-Concept Scope](docs/POC_SCOPE.md) and [Roadmap](docs/ROADMAP.md).
 
 Phase 1 work is tracked in the [`v0.2 Care Plan POC` tracking issue](https://github.com/jeffthomasiii/pawpath/issues/13), with one issue for each feature package and its acceptance criteria.
 
-The next implementation task is [POC-04: Build and persist one active trip care plan](https://github.com/jeffthomasiii/pawpath/issues/7).
+The next implementation task is [POC-05: Add persistent saved-plan summary](https://github.com/jeffthomasiii/pawpath/issues/8).
 
 ## Product documentation
 
@@ -105,9 +112,9 @@ The next implementation task is [POC-04: Build and persist one active trip care 
 - [OpenStreetMap](https://www.openstreetmap.org/) map tiles and clinic data
 - [Nominatim](https://nominatim.org/) for destination geocoding
 - [Overpass API](https://overpass-api.de/) for nearby veterinary-facility queries
-- Browser `localStorage` planned for the first saved care-plan implementation
+- Browser `localStorage` for the active care plan
 
-PawPath does not require a Google Maps API key. Google Maps is currently used only as an external destination for the **Directions** link.
+PawPath does not require a Google Maps API key. Google Maps is currently used only as an external destination for the **Directions** and emergency-search links.
 
 ## Project structure
 
@@ -119,11 +126,13 @@ pawpath/
 ├── styles.css               # Core responsive design system and components
 ├── site-fixes.css           # Map, brand, mode, and facility-detail enhancements
 ├── selection.css            # Primary and Backup selection components
+├── care-plan.css            # Saved active care-plan editor and mode-specific presentation
 ├── emergency-fallback.css   # Extended emergency-result presentation
 ├── leaflet-local.css        # Locally hosted Leaflet layout styles
 ├── app.js                   # Modes, map, facility classification, detail rendering, search, filters, and UI state
 ├── emergency-fallback.js    # Conditional 30-mile emergency and urgent-care fallback search
-├── selection.js             # Session-based Primary and Backup care-plan selection
+├── selection.js             # Primary and Backup care-plan selection
+├── care-plan.js             # Versioned local storage, validation, restore, update, and clear behavior
 ├── map-layout-fix.js        # Defensive Leaflet resize handling
 └── README.md                # Project overview
 ```
@@ -163,7 +172,7 @@ PawPath is not a veterinary diagnosis or medical-triage service. It does not gua
 
 ## Privacy
 
-Location information is used in the browser to perform the requested nearby search. PawPath does not currently maintain a backend or store the user’s location. The next saved-plan implementation is intended to remain on the user’s device through browser `localStorage`.
+Location information is used in the browser to perform the requested nearby search. PawPath does not currently maintain a backend or store the user’s location remotely. The active care plan is saved only in the current browser. Users should not enter medical documents, identification records, financial information, or other unnecessary sensitive data into the proof of concept.
 
 ## License
 

--- a/care-plan.css
+++ b/care-plan.css
@@ -1,0 +1,170 @@
+.care-plan-editor {
+  display: grid;
+  gap: 22px;
+  padding: clamp(22px, 4vw, 34px);
+  border: 1px solid var(--line);
+  border-radius: 22px;
+  background: var(--white);
+  box-shadow: var(--shadow-soft);
+}
+
+.care-plan-editor[hidden] {
+  display: none;
+}
+
+.care-plan-editor-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.care-plan-editor-heading h2 {
+  margin: 3px 0 0;
+}
+
+.care-plan-editor-heading > p {
+  max-width: 520px;
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.care-plan-saved-state {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: var(--surface-soft);
+  color: var(--muted);
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.care-plan-saved-state.is-saved {
+  background: #e8f3ed;
+  color: var(--green-dark);
+}
+
+.care-plan-form {
+  display: grid;
+  gap: 20px;
+}
+
+.care-plan-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.care-plan-field {
+  display: grid;
+  gap: 7px;
+}
+
+.care-plan-field.is-wide {
+  grid-column: 1 / -1;
+}
+
+.care-plan-field label {
+  color: var(--text);
+  font-size: 0.84rem;
+  font-weight: 800;
+}
+
+.care-plan-field input,
+.care-plan-field textarea {
+  width: 100%;
+  border: 1px solid var(--line-strong);
+  border-radius: 12px;
+  background: var(--white);
+  color: var(--text);
+  font: inherit;
+}
+
+.care-plan-field input {
+  min-height: 46px;
+  padding: 0 13px;
+}
+
+.care-plan-field textarea {
+  min-height: 92px;
+  padding: 12px 13px;
+  resize: vertical;
+}
+
+.care-plan-field input:focus,
+.care-plan-field textarea:focus {
+  border-color: var(--green);
+  outline: 3px solid rgba(57, 105, 88, 0.16);
+  outline-offset: 1px;
+}
+
+.care-plan-field small {
+  color: var(--muted);
+  font-size: 0.75rem;
+  line-height: 1.4;
+}
+
+.care-plan-privacy-note {
+  margin: 0;
+  padding: 12px 14px;
+  border-left: 3px solid var(--gold);
+  border-radius: 0 10px 10px 0;
+  background: #fff9ed;
+  color: #675434;
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.care-plan-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.care-plan-status {
+  min-height: 1.25em;
+  margin: 0;
+  color: var(--green-dark);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.care-plan-status.is-error {
+  color: var(--danger);
+}
+
+body[data-app-mode="now"] .care-plan-editor,
+body[data-app-mode="now"] .care-plan-selection,
+body[data-app-mode="now"] .facility-plan-selection {
+  display: none;
+}
+
+@media (max-width: 780px) {
+  .care-plan-editor-heading {
+    display: grid;
+  }
+
+  .care-plan-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .care-plan-field.is-wide {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 520px) {
+  .care-plan-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .care-plan-actions .button {
+    justify-content: center;
+    width: 100%;
+  }
+}

--- a/care-plan.css
+++ b/care-plan.css
@@ -2,10 +2,10 @@
   display: grid;
   gap: 22px;
   padding: clamp(22px, 4vw, 34px);
-  border: 1px solid var(--line);
+  border: 1px solid var(--border);
   border-radius: 22px;
   background: var(--white);
-  box-shadow: var(--shadow-soft);
+  box-shadow: var(--shadow-sm);
 }
 
 .care-plan-editor[hidden] {
@@ -23,11 +23,18 @@
   margin: 3px 0 0;
 }
 
-.care-plan-editor-heading > p {
+.care-plan-editor-heading > div:last-child {
+  display: grid;
+  justify-items: end;
+  gap: 8px;
   max-width: 520px;
+}
+
+.care-plan-editor-heading > div:last-child p {
   margin: 0;
-  color: var(--muted);
+  color: var(--ink-500);
   line-height: 1.55;
+  text-align: right;
 }
 
 .care-plan-saved-state {
@@ -36,15 +43,15 @@
   width: fit-content;
   padding: 6px 10px;
   border-radius: 999px;
-  background: var(--surface-soft);
-  color: var(--muted);
+  background: var(--sage-50);
+  color: var(--ink-500);
   font-size: 0.78rem;
   font-weight: 800;
 }
 
 .care-plan-saved-state.is-saved {
-  background: #e8f3ed;
-  color: var(--green-dark);
+  background: var(--sage-100);
+  color: var(--forest-900);
 }
 
 .care-plan-form {
@@ -68,7 +75,7 @@
 }
 
 .care-plan-field label {
-  color: var(--text);
+  color: var(--ink-900);
   font-size: 0.84rem;
   font-weight: 800;
 }
@@ -76,10 +83,10 @@
 .care-plan-field input,
 .care-plan-field textarea {
   width: 100%;
-  border: 1px solid var(--line-strong);
+  border: 1px solid var(--border);
   border-radius: 12px;
   background: var(--white);
-  color: var(--text);
+  color: var(--ink-900);
   font: inherit;
 }
 
@@ -96,13 +103,13 @@
 
 .care-plan-field input:focus,
 .care-plan-field textarea:focus {
-  border-color: var(--green);
-  outline: 3px solid rgba(57, 105, 88, 0.16);
+  border-color: var(--forest-700);
+  outline: 3px solid rgba(43, 106, 89, 0.16);
   outline-offset: 1px;
 }
 
 .care-plan-field small {
-  color: var(--muted);
+  color: var(--ink-500);
   font-size: 0.75rem;
   line-height: 1.4;
 }
@@ -110,7 +117,7 @@
 .care-plan-privacy-note {
   margin: 0;
   padding: 12px 14px;
-  border-left: 3px solid var(--gold);
+  border-left: 3px solid var(--amber-500);
   border-radius: 0 10px 10px 0;
   background: #fff9ed;
   color: #675434;
@@ -128,7 +135,7 @@
 .care-plan-status {
   min-height: 1.25em;
   margin: 0;
-  color: var(--green-dark);
+  color: var(--forest-900);
   font-size: 0.82rem;
   font-weight: 700;
 }
@@ -146,6 +153,14 @@ body[data-app-mode="now"] .facility-plan-selection {
 @media (max-width: 780px) {
   .care-plan-editor-heading {
     display: grid;
+  }
+
+  .care-plan-editor-heading > div:last-child {
+    justify-items: start;
+  }
+
+  .care-plan-editor-heading > div:last-child p {
+    text-align: left;
   }
 
   .care-plan-fields {

--- a/care-plan.js
+++ b/care-plan.js
@@ -1,0 +1,373 @@
+const CARE_PLAN_STORAGE_KEY = "pawpath.activeCarePlan.v1";
+const CARE_PLAN_SCHEMA_VERSION = 1;
+
+const originalSetModeForCarePlan = setMode;
+const originalSearchNearbyForCarePlan = searchNearby;
+const originalRefreshSelectionPresentationForCarePlan = refreshSelectionPresentation;
+
+let carePlanElements = {};
+let activeStoredPlan = readStoredCarePlan();
+let hasSavedCarePlan = Boolean(activeStoredPlan);
+let skipFirstDestinationSync = hasSavedCarePlan;
+let carePlanSaveTimer = null;
+
+setMode = function setModeWithCarePlan(mode, announce = false) {
+  originalSetModeForCarePlan(mode, announce);
+  applyCarePlanMode(mode);
+};
+
+searchNearby = async function searchNearbyWithCarePlanDestination(center, label) {
+  await originalSearchNearbyForCarePlan(center, label);
+
+  if (skipFirstDestinationSync) {
+    skipFirstDestinationSync = false;
+    return;
+  }
+
+  if (activeMode === "plan" && carePlanElements.destination) {
+    carePlanElements.destination.value = label || currentSearchLabel || "";
+    scheduleCarePlanSave("Destination updated.");
+  }
+};
+
+refreshSelectionPresentation = function refreshSelectionPresentationWithStorage() {
+  originalRefreshSelectionPresentationForCarePlan();
+  scheduleCarePlanSave("Care-plan facilities updated.");
+};
+
+document.addEventListener("DOMContentLoaded", initializeCarePlanPersistence);
+
+function initializeCarePlanPersistence() {
+  carePlanElements = {
+    section: document.getElementById("care-plan-editor"),
+    form: document.getElementById("care-plan-form"),
+    name: document.getElementById("trip-name"),
+    destination: document.getElementById("trip-destination"),
+    startDate: document.getElementById("trip-start-date"),
+    endDate: document.getElementById("trip-end-date"),
+    petName: document.getElementById("pet-name"),
+    ownerPhone: document.getElementById("owner-phone"),
+    petNote: document.getElementById("pet-note"),
+    saveButton: document.getElementById("save-care-plan"),
+    clearButton: document.getElementById("clear-care-plan"),
+    status: document.getElementById("care-plan-status"),
+    savedState: document.getElementById("care-plan-saved-state"),
+    selectionSection: document.getElementById("care-plan-selection"),
+    facilitySelection: document.querySelector(".facility-plan-selection"),
+  };
+
+  carePlanElements.form.addEventListener("submit", handleCarePlanSubmit);
+  carePlanElements.clearButton.addEventListener("click", clearActiveCarePlan);
+
+  [
+    carePlanElements.name,
+    carePlanElements.destination,
+    carePlanElements.startDate,
+    carePlanElements.endDate,
+    carePlanElements.petName,
+    carePlanElements.ownerPhone,
+    carePlanElements.petNote,
+  ].forEach((field) => {
+    field.addEventListener("input", () => scheduleCarePlanSave("Care-plan details updated."));
+    field.addEventListener("change", () => scheduleCarePlanSave("Care-plan details updated."));
+  });
+
+  if (activeStoredPlan) {
+    restoreCarePlan(activeStoredPlan);
+    announceCarePlan("Saved care plan restored from this browser.");
+  } else {
+    carePlanElements.destination.value = currentSearchLabel || "";
+    updateSavedState();
+  }
+
+  applyCarePlanMode(activeMode);
+}
+
+function handleCarePlanSubmit(event) {
+  event.preventDefault();
+  const validationMessage = validateCarePlanForm();
+
+  if (validationMessage) {
+    announceCarePlan(validationMessage, true);
+    return;
+  }
+
+  persistCarePlan(hasSavedCarePlan ? "Care plan updated." : "Care plan saved to this browser.");
+}
+
+function validateCarePlanForm() {
+  if (!carePlanElements.name.value.trim()) {
+    carePlanElements.name.focus();
+    return "Add a trip name before saving the care plan.";
+  }
+
+  if (!carePlanElements.destination.value.trim()) {
+    carePlanElements.destination.focus();
+    return "Add a destination before saving the care plan.";
+  }
+
+  if (!planSelections.primary) {
+    return "Select a Primary emergency or urgent-care facility before saving.";
+  }
+
+  if (!planSelections.backup) {
+    return "Select a distinct Backup facility before saving.";
+  }
+
+  if (
+    carePlanElements.startDate.value &&
+    carePlanElements.endDate.value &&
+    carePlanElements.endDate.value < carePlanElements.startDate.value
+  ) {
+    carePlanElements.endDate.focus();
+    return "The trip end date cannot be before the start date.";
+  }
+
+  return "";
+}
+
+function persistCarePlan(message, announce = true) {
+  if (!hasSavedCarePlan && !message) return;
+
+  const validationMessage = validateCarePlanFormWithoutFocus();
+  if (validationMessage) {
+    if (announce) announceCarePlan(validationMessage, true);
+    return;
+  }
+
+  const now = new Date().toISOString();
+  const plan = {
+    schemaVersion: CARE_PLAN_SCHEMA_VERSION,
+    id: activeStoredPlan?.id || createCarePlanId(),
+    createdAt: activeStoredPlan?.createdAt || now,
+    updatedAt: now,
+    trip: {
+      name: carePlanElements.name.value.trim(),
+      destination: carePlanElements.destination.value.trim(),
+      startDate: carePlanElements.startDate.value || "",
+      endDate: carePlanElements.endDate.value || "",
+    },
+    traveler: {
+      petName: carePlanElements.petName.value.trim(),
+      ownerPhone: carePlanElements.ownerPhone.value.trim(),
+      importantNote: carePlanElements.petNote.value.trim(),
+    },
+    facilities: {
+      primary: sanitizeFacility(planSelections.primary),
+      backup: sanitizeFacility(planSelections.backup),
+      routine: null,
+    },
+  };
+
+  try {
+    localStorage.setItem(CARE_PLAN_STORAGE_KEY, JSON.stringify(plan));
+    activeStoredPlan = plan;
+    hasSavedCarePlan = true;
+    updateSavedState();
+    if (announce && message) announceCarePlan(message);
+  } catch (error) {
+    console.error("Care plan could not be saved:", error);
+    announceCarePlan("This browser could not save the care plan. Check storage settings and try again.", true);
+  }
+}
+
+function scheduleCarePlanSave(message) {
+  if (!hasSavedCarePlan || !carePlanElements.form) return;
+
+  window.clearTimeout(carePlanSaveTimer);
+  carePlanSaveTimer = window.setTimeout(() => {
+    persistCarePlan(message, false);
+  }, 350);
+}
+
+function clearActiveCarePlan() {
+  if (!hasSavedCarePlan && !planSelections.primary && !planSelections.backup) {
+    announceCarePlan("There is no saved care plan to clear.");
+    return;
+  }
+
+  const shouldClear = window.confirm(
+    "Clear the saved trip details and remove the Primary and Backup selections from this browser?"
+  );
+  if (!shouldClear) return;
+
+  try {
+    localStorage.removeItem(CARE_PLAN_STORAGE_KEY);
+  } catch (error) {
+    console.warn("Stored care plan could not be removed:", error);
+  }
+
+  activeStoredPlan = null;
+  hasSavedCarePlan = false;
+  planSelections.primary = null;
+  planSelections.backup = null;
+  carePlanElements.form.reset();
+  carePlanElements.destination.value = currentSearchLabel || "";
+  renderSelectionSummary();
+  renderClinics({ preserveView: true });
+  updateSavedState();
+  announceCarePlan("Care plan cleared from this browser.");
+}
+
+function restoreCarePlan(plan) {
+  carePlanElements.name.value = plan.trip.name;
+  carePlanElements.destination.value = plan.trip.destination;
+  carePlanElements.startDate.value = plan.trip.startDate;
+  carePlanElements.endDate.value = plan.trip.endDate;
+  carePlanElements.petName.value = plan.traveler.petName;
+  carePlanElements.ownerPhone.value = plan.traveler.ownerPhone;
+  carePlanElements.petNote.value = plan.traveler.importantNote;
+
+  planSelections.primary = plan.facilities.primary ? { ...plan.facilities.primary } : null;
+  planSelections.backup = plan.facilities.backup ? { ...plan.facilities.backup } : null;
+  renderSelectionSummary();
+  updateSavedState();
+}
+
+function readStoredCarePlan() {
+  let rawValue;
+
+  try {
+    rawValue = localStorage.getItem(CARE_PLAN_STORAGE_KEY);
+  } catch (error) {
+    console.warn("Care-plan storage is unavailable:", error);
+    return null;
+  }
+
+  if (!rawValue) return null;
+
+  try {
+    const parsed = JSON.parse(rawValue);
+    if (!isValidStoredCarePlan(parsed)) throw new Error("Unsupported or malformed care-plan data.");
+    return parsed;
+  } catch (error) {
+    console.warn("Stored care plan was ignored:", error);
+    try {
+      localStorage.removeItem(CARE_PLAN_STORAGE_KEY);
+    } catch {
+      // Storage may be blocked; failing safely is sufficient.
+    }
+    return null;
+  }
+}
+
+function isValidStoredCarePlan(value) {
+  if (!value || typeof value !== "object") return false;
+  if (value.schemaVersion !== CARE_PLAN_SCHEMA_VERSION) return false;
+  if (!isNonEmptyString(value.id) || !isIsoDate(value.createdAt) || !isIsoDate(value.updatedAt)) return false;
+  if (!value.trip || !isNonEmptyString(value.trip.name) || !isNonEmptyString(value.trip.destination)) return false;
+  if (!isOptionalDate(value.trip.startDate) || !isOptionalDate(value.trip.endDate)) return false;
+  if (!value.traveler || typeof value.traveler !== "object") return false;
+  if (!isString(value.traveler.petName) || !isString(value.traveler.ownerPhone) || !isString(value.traveler.importantNote)) return false;
+  if (!value.facilities || !isValidFacility(value.facilities.primary) || !isValidFacility(value.facilities.backup)) return false;
+  if (value.facilities.primary.id === value.facilities.backup.id) return false;
+  return true;
+}
+
+function isValidFacility(facility) {
+  if (!facility || typeof facility !== "object") return false;
+  return (
+    isNonEmptyString(facility.id) &&
+    isNonEmptyString(facility.name) &&
+    isString(facility.address) &&
+    Number.isFinite(facility.lat) &&
+    Number.isFinite(facility.lng) &&
+    Number.isFinite(facility.distanceMiles) &&
+    isNonEmptyString(facility.careType)
+  );
+}
+
+function sanitizeFacility(facility) {
+  if (!facility) return null;
+
+  return {
+    id: String(facility.id),
+    name: String(facility.name || "Veterinary facility"),
+    address: String(facility.address || ""),
+    phone: String(facility.phone || ""),
+    website: String(facility.website || ""),
+    hours: String(facility.hours || ""),
+    careType: String(facility.careType || "unknown"),
+    confidence: String(facility.confidence || "needs-confirmation"),
+    emergency: Boolean(facility.emergency),
+    source: String(facility.source || ""),
+    sourceUrl: String(facility.sourceUrl || ""),
+    sourceNotes: String(facility.sourceNotes || ""),
+    lat: Number(facility.lat),
+    lng: Number(facility.lng),
+    distanceMiles: Number(facility.distanceMiles),
+    isExtendedEmergencySearch: Boolean(facility.isExtendedEmergencySearch),
+  };
+}
+
+function validateCarePlanFormWithoutFocus() {
+  if (!carePlanElements.name.value.trim()) return "The saved plan needs a trip name.";
+  if (!carePlanElements.destination.value.trim()) return "The saved plan needs a destination.";
+  if (!planSelections.primary || !planSelections.backup) return "The saved plan needs Primary and Backup facilities.";
+  if (
+    carePlanElements.startDate.value &&
+    carePlanElements.endDate.value &&
+    carePlanElements.endDate.value < carePlanElements.startDate.value
+  ) {
+    return "The trip dates are invalid.";
+  }
+  return "";
+}
+
+function applyCarePlanMode(mode) {
+  document.body.dataset.appMode = mode;
+  const isPlanning = mode === "plan";
+
+  if (carePlanElements.section) carePlanElements.section.hidden = !isPlanning;
+  if (carePlanElements.selectionSection) carePlanElements.selectionSection.hidden = !isPlanning;
+  if (carePlanElements.facilitySelection) carePlanElements.facilitySelection.hidden = !isPlanning;
+}
+
+function updateSavedState() {
+  if (!carePlanElements.savedState || !carePlanElements.clearButton || !carePlanElements.saveButton) return;
+
+  if (!hasSavedCarePlan || !activeStoredPlan) {
+    carePlanElements.savedState.textContent = "Not saved yet";
+    carePlanElements.savedState.classList.remove("is-saved");
+    carePlanElements.clearButton.hidden = true;
+    carePlanElements.saveButton.textContent = "Save care plan";
+    return;
+  }
+
+  const updated = new Date(activeStoredPlan.updatedAt);
+  carePlanElements.savedState.textContent = `Saved locally · ${updated.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  })}`;
+  carePlanElements.savedState.classList.add("is-saved");
+  carePlanElements.clearButton.hidden = false;
+  carePlanElements.saveButton.textContent = "Update care plan";
+}
+
+function announceCarePlan(message, isError = false) {
+  carePlanElements.status.textContent = message;
+  carePlanElements.status.classList.toggle("is-error", isError);
+}
+
+function createCarePlanId() {
+  if (crypto?.randomUUID) return crypto.randomUUID();
+  return `care-plan-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function isString(value) {
+  return typeof value === "string";
+}
+
+function isNonEmptyString(value) {
+  return isString(value) && Boolean(value.trim());
+}
+
+function isIsoDate(value) {
+  return isNonEmptyString(value) && !Number.isNaN(Date.parse(value));
+}
+
+function isOptionalDate(value) {
+  return value === "" || /^\d{4}-\d{2}-\d{2}$/.test(value);
+}

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <link rel="stylesheet" href="styles.css" />
     <link rel="stylesheet" href="site-fixes.css" />
     <link rel="stylesheet" href="selection.css" />
+    <link rel="stylesheet" href="care-plan.css" />
     <link rel="stylesheet" href="emergency-fallback.css" />
   </head>
 
@@ -86,6 +87,69 @@
           <p id="form-message" class="form-message" role="status" aria-live="polite"></p>
         </form>
         <p id="mode-status" class="sr-only" aria-live="polite"></p>
+      </section>
+
+      <section id="care-plan-editor" class="care-plan-editor" aria-labelledby="care-plan-editor-title">
+        <div class="care-plan-editor-heading">
+          <div>
+            <p class="eyebrow">Plan a Trip</p>
+            <h2 id="care-plan-editor-title">Save the essential details for this trip.</h2>
+          </div>
+          <div>
+            <span id="care-plan-saved-state" class="care-plan-saved-state">Not saved yet</span>
+            <p>One active plan is stored only in this browser. No account or backend is required.</p>
+          </div>
+        </div>
+
+        <form id="care-plan-form" class="care-plan-form" novalidate>
+          <div class="care-plan-fields">
+            <div class="care-plan-field">
+              <label for="trip-name">Trip name <span aria-hidden="true">*</span></label>
+              <input id="trip-name" name="tripName" type="text" maxlength="80" autocomplete="off" placeholder="Big Bear camping trip" required />
+            </div>
+
+            <div class="care-plan-field">
+              <label for="trip-destination">Destination <span aria-hidden="true">*</span></label>
+              <input id="trip-destination" name="tripDestination" type="text" maxlength="140" autocomplete="off" required />
+            </div>
+
+            <div class="care-plan-field">
+              <label for="trip-start-date">Start date <span class="sr-only">optional</span></label>
+              <input id="trip-start-date" name="tripStartDate" type="date" />
+            </div>
+
+            <div class="care-plan-field">
+              <label for="trip-end-date">End date <span class="sr-only">optional</span></label>
+              <input id="trip-end-date" name="tripEndDate" type="date" />
+            </div>
+
+            <div class="care-plan-field">
+              <label for="pet-name">Pet name <span class="sr-only">optional</span></label>
+              <input id="pet-name" name="petName" type="text" maxlength="60" autocomplete="off" placeholder="Olive" />
+            </div>
+
+            <div class="care-plan-field">
+              <label for="owner-phone">Owner phone <span class="sr-only">optional</span></label>
+              <input id="owner-phone" name="ownerPhone" type="tel" maxlength="40" autocomplete="tel" placeholder="(555) 555-0123" />
+            </div>
+
+            <div class="care-plan-field is-wide">
+              <label for="pet-note">Important pet note <span class="sr-only">optional</span></label>
+              <textarea id="pet-note" name="petNote" maxlength="240" placeholder="Allergies, medications, temperament, or another short detail that may help during travel."></textarea>
+              <small>Keep this brief. Do not store medical records, identification documents, or other sensitive files in this proof of concept.</small>
+            </div>
+          </div>
+
+          <p class="care-plan-privacy-note">
+            <strong>Stored on this device:</strong> PawPath saves one care plan in this browser using local storage. Clearing browser data will remove it.
+          </p>
+
+          <div class="care-plan-actions">
+            <button id="save-care-plan" class="button button-primary" type="submit">Save care plan</button>
+            <button id="clear-care-plan" class="button button-secondary" type="button" hidden>Clear plan</button>
+          </div>
+          <p id="care-plan-status" class="care-plan-status" role="status" aria-live="polite"></p>
+        </form>
       </section>
 
       <section id="care-plan-selection" class="care-plan-selection" aria-labelledby="care-plan-selection-title">
@@ -240,6 +304,7 @@
     <script src="app.js" defer></script>
     <script src="emergency-fallback.js" defer></script>
     <script src="selection.js" defer></script>
+    <script src="care-plan.js" defer></script>
     <script src="map-layout-fix.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## What changed

- added a Plan a Trip editor for trip name, destination, optional dates, pet name, owner phone, and one brief important pet note
- save one active care plan locally with the versioned key `pawpath.activeCarePlan.v1`
- include schema version, plan ID, created timestamp, and updated timestamp
- restore saved trip details and Primary/Backup facility snapshots after refresh
- validate stored data and discard malformed or unsupported records safely
- require trip name, destination, Primary, and Backup for explicit save/update
- automatically update an existing saved plan when trip details or facility choices change
- add a confirmed Clear Plan action that removes storage and current selections
- hide the trip editor, care-plan choices, and facility-selection controls in Find Care Now mode
- add responsive styling and privacy guidance explaining that data stays in the current browser
- update the README and point active development to POC-05

## Validation

- reviewed the branch diff against `main`
- confirmed all new form IDs match the persistence module lookups
- confirmed script order is `app.js`, emergency fallback, selection, care plan, then map layout handling
- confirmed the new CSS uses PawPath’s existing design tokens
- confirmed storage uses no backend and contains only short text fields and facility snapshots

The repository has no automated browser-test suite, so save/refresh/restore, malformed-storage handling, clear behavior, and mobile layout still require a deployed browser check.

Closes #7