### PR TITLE
Add persistent saved plan summary

### DIFF
--- a/map-layout-fix.js
+++ b/map-layout-fix.js
@@ -12,6 +12,13 @@ document.head.append(planSummaryScript);
 /* Keep Leaflet synchronized with responsive layout changes. */
 
 document.addEventListener("DOMContentLoaded", () => {
+  const editorClearButton = document.getElementById("clear-care-plan");
+  editorClearButton?.addEventListener("click", () => {
+    window.setTimeout(() => {
+      if (typeof renderSavedPlanSummary === "function") renderSavedPlanSummary();
+    }, 0);
+  });
+
   const mapElement = document.getElementById("map");
   if (!mapElement) return;
 

--- a/map-layout-fix.js
+++ b/map-layout-fix.js
@@ -1,3 +1,14 @@
+/* Load the saved-plan summary after the core care-plan module is available. */
+
+const planSummaryStylesheet = document.createElement("link");
+planSummaryStylesheet.rel = "stylesheet";
+planSummaryStylesheet.href = "plan-summary.css";
+document.head.append(planSummaryStylesheet);
+
+const planSummaryScript = document.createElement("script");
+planSummaryScript.src = "plan-summary.js";
+document.head.append(planSummaryScript);
+
 /* Keep Leaflet synchronized with responsive layout changes. */
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/plan-summary.css
+++ b/plan-summary.css
@@ -1,0 +1,189 @@
+.saved-plan-summary {
+  display: grid;
+  gap: 18px;
+  padding: clamp(20px, 4vw, 30px);
+  border: 1px solid var(--border);
+  border-radius: 22px;
+  background: linear-gradient(180deg, #f8fbf9, var(--white));
+  box-shadow: var(--shadow-sm);
+}
+
+.saved-plan-summary[hidden] {
+  display: none;
+}
+
+.saved-plan-summary.is-emergency-active {
+  border-color: rgba(163, 62, 50, 0.4);
+  background: linear-gradient(180deg, #fff5f2, var(--white));
+  box-shadow: 0 18px 48px rgba(163, 62, 50, 0.12);
+}
+
+.saved-plan-summary-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.saved-plan-summary-header h2 {
+  margin: 3px 0 2px;
+}
+
+.saved-plan-destination {
+  margin: 0;
+  color: var(--ink-500);
+}
+
+.saved-plan-emergency-button {
+  flex: 0 0 auto;
+  border-color: var(--danger);
+  background: var(--danger);
+  color: var(--white);
+}
+
+.saved-plan-emergency-button:hover,
+.saved-plan-emergency-button:focus-visible {
+  background: #862f27;
+}
+
+.saved-plan-trip-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  color: var(--ink-500);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.saved-plan-trip-meta span:not(:last-child)::after {
+  content: "•";
+  margin-left: 14px;
+  color: var(--amber-500);
+}
+
+.saved-plan-facilities {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.saved-facility-card {
+  display: grid;
+  align-content: start;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--white);
+}
+
+.saved-facility-card.is-primary {
+  border-color: rgba(163, 62, 50, 0.3);
+}
+
+.saved-facility-card.is-backup {
+  border-color: rgba(216, 148, 63, 0.4);
+}
+
+.saved-facility-card-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.saved-facility-care-type {
+  color: var(--ink-500);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.saved-facility-card h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.saved-facility-card p {
+  margin: 0;
+  color: var(--ink-500);
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
+.saved-facility-distance {
+  font-weight: 700;
+}
+
+.saved-facility-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.saved-facility-action {
+  min-height: 38px;
+  padding: 8px 12px;
+  font-size: 0.78rem;
+}
+
+.saved-plan-summary-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.saved-plan-secondary-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.saved-plan-call-ahead {
+  margin: 0;
+  color: var(--ink-500);
+  font-size: 0.76rem;
+}
+
+@media (max-width: 760px) {
+  .saved-plan-summary-header,
+  .saved-plan-summary-footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .saved-plan-emergency-button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .saved-plan-facilities {
+    grid-template-columns: 1fr;
+  }
+
+  .saved-plan-call-ahead {
+    order: -1;
+  }
+}
+
+@media (max-width: 480px) {
+  .saved-plan-trip-meta {
+    display: grid;
+    gap: 5px;
+  }
+
+  .saved-plan-trip-meta span::after {
+    display: none;
+  }
+
+  .saved-facility-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .saved-facility-action {
+    justify-content: center;
+    width: 100%;
+  }
+}

--- a/plan-summary.js
+++ b/plan-summary.js
@@ -9,8 +9,10 @@ persistCarePlan = function persistCarePlanWithSummary(message, announce = true) 
 };
 
 clearActiveCarePlan = function clearActiveCarePlanWithSummary() {
+  const hadSavedPlan = Boolean(hasSavedCarePlan || activeStoredPlan);
   originalClearActiveCarePlanForSummary();
   renderSavedPlanSummary();
+  return hadSavedPlan && !hasSavedCarePlan && !activeStoredPlan;
 };
 
 if (document.readyState === "loading") {
@@ -45,10 +47,15 @@ function initializeSavedPlanSummary() {
 
   planSummaryElements.edit.addEventListener("click", editSavedPlan);
   planSummaryElements.clear.addEventListener("click", () => {
-    clearActiveCarePlan();
-    announceSavedPlan("Saved plan cleared.");
+    if (clearActiveCarePlan()) announceSavedPlan("Saved plan cleared.");
   });
   planSummaryElements.emergency.addEventListener("click", openSavedPlanEmergencyMode);
+
+  document.querySelectorAll(".mode-option").forEach((button) => {
+    button.addEventListener("click", () => {
+      if (button.dataset.mode === "plan") resetSavedPlanEmergencyState();
+    });
+  });
 
   renderSavedPlanSummary();
 }
@@ -101,7 +108,7 @@ function renderSavedPlanSummary() {
 
   if (!activeStoredPlan || !hasSavedCarePlan) {
     planSummaryElements.region.hidden = true;
-    planSummaryElements.region.classList.remove("is-emergency-active");
+    resetSavedPlanEmergencyState();
     planSummaryElements.facilities.innerHTML = "";
     return;
   }
@@ -132,7 +139,7 @@ function createSavedFacilityCard(roleLabel, facility, role) {
   card.innerHTML = `
     <div class="saved-facility-card-heading">
       <span class="selection-role-label ${roleClass}">${roleLabel}</span>
-      <span class="saved-facility-care-type">${escapeHtml(formatCareType(facility.careType))}</span>
+      <span class="saved-facility-care-type">${escapeHtml(formatSavedCareType(facility.careType))}</span>
     </div>
     <h3>${escapeHtml(facility.name)}</h3>
     <p>${escapeHtml(facility.address || "Address not listed")}</p>
@@ -171,7 +178,7 @@ function createFacilityDirectionsAction(facility) {
 
 function editSavedPlan() {
   setMode("plan", true);
-  planSummaryElements.region.classList.remove("is-emergency-active");
+  resetSavedPlanEmergencyState();
 
   const editor = document.getElementById("care-plan-editor");
   editor?.scrollIntoView({ behavior: prefersReducedMotion() ? "auto" : "smooth", block: "start" });
@@ -188,6 +195,12 @@ function openSavedPlanEmergencyMode() {
   const firstCall = planSummaryElements.region.querySelector('.saved-facility-card.is-primary a[href^="tel:"]');
   window.setTimeout(() => (firstCall || planSummaryElements.emergency).focus({ preventScroll: true }), 250);
   announceSavedPlan("Emergency Mode opened. Primary and Backup call and directions actions are ready.");
+}
+
+function resetSavedPlanEmergencyState() {
+  if (!planSummaryElements.region || !planSummaryElements.emergency) return;
+  planSummaryElements.region.classList.remove("is-emergency-active");
+  planSummaryElements.emergency.textContent = "Open Emergency Mode";
 }
 
 function announceSavedPlan(message) {
@@ -215,7 +228,7 @@ function formatSavedPlanTimestamp(value) {
   return date.toLocaleString([], { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
 }
 
-function formatCareType(value) {
+function formatSavedCareType(value) {
   if (value === "emergency") return "Emergency care";
   if (value === "urgent") return "Urgent care";
   if (value === "routine") return "Routine care";

--- a/plan-summary.js
+++ b/plan-summary.js
@@ -1,0 +1,234 @@
+const originalPersistCarePlanForSummary = persistCarePlan;
+const originalClearActiveCarePlanForSummary = clearActiveCarePlan;
+
+let planSummaryElements = {};
+
+persistCarePlan = function persistCarePlanWithSummary(message, announce = true) {
+  originalPersistCarePlanForSummary(message, announce);
+  renderSavedPlanSummary();
+};
+
+clearActiveCarePlan = function clearActiveCarePlanWithSummary() {
+  originalClearActiveCarePlanForSummary();
+  renderSavedPlanSummary();
+};
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initializeSavedPlanSummary);
+} else {
+  initializeSavedPlanSummary();
+}
+
+window.addEventListener("storage", (event) => {
+  if (event.key !== CARE_PLAN_STORAGE_KEY) return;
+  activeStoredPlan = readStoredCarePlan();
+  hasSavedCarePlan = Boolean(activeStoredPlan);
+  renderSavedPlanSummary();
+});
+
+function initializeSavedPlanSummary() {
+  injectPlanSummaryRegion();
+
+  planSummaryElements = {
+    region: document.getElementById("saved-plan-summary"),
+    title: document.getElementById("saved-plan-title"),
+    destination: document.getElementById("saved-plan-destination"),
+    dates: document.getElementById("saved-plan-dates"),
+    pet: document.getElementById("saved-plan-pet"),
+    updated: document.getElementById("saved-plan-updated"),
+    facilities: document.getElementById("saved-plan-facilities"),
+    edit: document.getElementById("saved-plan-edit"),
+    clear: document.getElementById("saved-plan-clear"),
+    emergency: document.getElementById("saved-plan-emergency"),
+    status: document.getElementById("saved-plan-status"),
+  };
+
+  planSummaryElements.edit.addEventListener("click", editSavedPlan);
+  planSummaryElements.clear.addEventListener("click", () => {
+    clearActiveCarePlan();
+    announceSavedPlan("Saved plan cleared.");
+  });
+  planSummaryElements.emergency.addEventListener("click", openSavedPlanEmergencyMode);
+
+  renderSavedPlanSummary();
+}
+
+function injectPlanSummaryRegion() {
+  if (document.getElementById("saved-plan-summary")) return;
+
+  const region = document.createElement("section");
+  region.id = "saved-plan-summary";
+  region.className = "saved-plan-summary";
+  region.hidden = true;
+  region.setAttribute("aria-labelledby", "saved-plan-title");
+
+  region.innerHTML = `
+    <div class="saved-plan-summary-header">
+      <div>
+        <p class="eyebrow">Active care plan</p>
+        <h2 id="saved-plan-title">Saved trip plan</h2>
+        <p id="saved-plan-destination" class="saved-plan-destination"></p>
+      </div>
+      <button id="saved-plan-emergency" class="button saved-plan-emergency-button" type="button">
+        Open Emergency Mode
+      </button>
+    </div>
+
+    <div class="saved-plan-trip-meta" aria-label="Saved trip details">
+      <span id="saved-plan-dates"></span>
+      <span id="saved-plan-pet"></span>
+      <span id="saved-plan-updated"></span>
+    </div>
+
+    <div id="saved-plan-facilities" class="saved-plan-facilities"></div>
+
+    <div class="saved-plan-summary-footer">
+      <div class="saved-plan-secondary-actions">
+        <button id="saved-plan-edit" class="text-button" type="button">Edit Plan</button>
+        <button id="saved-plan-clear" class="text-button is-destructive" type="button">Clear Plan</button>
+      </div>
+      <p class="saved-plan-call-ahead">Call ahead to confirm services, hours, and availability.</p>
+    </div>
+    <p id="saved-plan-status" class="sr-only" role="status" aria-live="polite"></p>
+  `;
+
+  const hero = document.getElementById("hero-panel");
+  hero?.insertAdjacentElement("afterend", region);
+}
+
+function renderSavedPlanSummary() {
+  if (!planSummaryElements.region) return;
+
+  if (!activeStoredPlan || !hasSavedCarePlan) {
+    planSummaryElements.region.hidden = true;
+    planSummaryElements.region.classList.remove("is-emergency-active");
+    planSummaryElements.facilities.innerHTML = "";
+    return;
+  }
+
+  const plan = activeStoredPlan;
+  planSummaryElements.region.hidden = false;
+  planSummaryElements.title.textContent = plan.trip.name;
+  planSummaryElements.destination.textContent = plan.trip.destination;
+  planSummaryElements.dates.textContent = formatSavedPlanDates(plan.trip.startDate, plan.trip.endDate);
+  planSummaryElements.pet.textContent = plan.traveler.petName ? `Pet: ${plan.traveler.petName}` : "Pet name not added";
+  planSummaryElements.updated.textContent = `Updated ${formatSavedPlanTimestamp(plan.updatedAt)}`;
+
+  planSummaryElements.facilities.innerHTML = "";
+  planSummaryElements.facilities.append(
+    createSavedFacilityCard("Primary", plan.facilities.primary, "primary"),
+    createSavedFacilityCard("Backup", plan.facilities.backup, "backup")
+  );
+}
+
+function createSavedFacilityCard(roleLabel, facility, role) {
+  const card = document.createElement("article");
+  card.className = `saved-facility-card is-${role}`;
+
+  const roleClass = role === "primary" ? "is-primary" : "is-backup";
+  const phoneAction = createFacilityPhoneAction(facility);
+  const directionsAction = createFacilityDirectionsAction(facility);
+
+  card.innerHTML = `
+    <div class="saved-facility-card-heading">
+      <span class="selection-role-label ${roleClass}">${roleLabel}</span>
+      <span class="saved-facility-care-type">${escapeHtml(formatCareType(facility.careType))}</span>
+    </div>
+    <h3>${escapeHtml(facility.name)}</h3>
+    <p>${escapeHtml(facility.address || "Address not listed")}</p>
+    <p class="saved-facility-distance">${Number.isFinite(facility.distanceMiles) ? `${facility.distanceMiles.toFixed(1)} mi from saved destination` : "Distance unavailable"}</p>
+    <div class="saved-facility-actions"></div>
+  `;
+
+  const actions = card.querySelector(".saved-facility-actions");
+  if (phoneAction) actions.append(phoneAction);
+  actions.append(directionsAction);
+
+  return card;
+}
+
+function createFacilityPhoneAction(facility) {
+  if (!facility.phone) return null;
+
+  const link = document.createElement("a");
+  link.className = "button button-primary saved-facility-action";
+  link.href = `tel:${facility.phone.replace(/[^+\d]/g, "")}`;
+  link.textContent = "Call";
+  link.setAttribute("aria-label", `Call ${facility.name}`);
+  return link;
+}
+
+function createFacilityDirectionsAction(facility) {
+  const link = document.createElement("a");
+  link.className = "button button-secondary saved-facility-action";
+  link.href = buildSavedFacilityDirectionsUrl(facility);
+  link.target = "_blank";
+  link.rel = "noopener noreferrer";
+  link.textContent = "Directions ↗";
+  link.setAttribute("aria-label", `Open directions to ${facility.name}`);
+  return link;
+}
+
+function editSavedPlan() {
+  setMode("plan", true);
+  planSummaryElements.region.classList.remove("is-emergency-active");
+
+  const editor = document.getElementById("care-plan-editor");
+  editor?.scrollIntoView({ behavior: prefersReducedMotion() ? "auto" : "smooth", block: "start" });
+  window.setTimeout(() => document.getElementById("trip-name")?.focus({ preventScroll: true }), 250);
+  announceSavedPlan("Plan a Trip opened for editing.");
+}
+
+function openSavedPlanEmergencyMode() {
+  setMode("now", true);
+  planSummaryElements.region.classList.add("is-emergency-active");
+  planSummaryElements.emergency.textContent = "Emergency Mode Active";
+  planSummaryElements.region.scrollIntoView({ behavior: prefersReducedMotion() ? "auto" : "smooth", block: "start" });
+
+  const firstCall = planSummaryElements.region.querySelector('.saved-facility-card.is-primary a[href^="tel:"]');
+  window.setTimeout(() => (firstCall || planSummaryElements.emergency).focus({ preventScroll: true }), 250);
+  announceSavedPlan("Emergency Mode opened. Primary and Backup call and directions actions are ready.");
+}
+
+function announceSavedPlan(message) {
+  if (!planSummaryElements.status) return;
+  planSummaryElements.status.textContent = "";
+  window.requestAnimationFrame(() => {
+    planSummaryElements.status.textContent = message;
+  });
+}
+
+function formatSavedPlanDates(startDate, endDate) {
+  if (!startDate && !endDate) return "Travel dates not added";
+  if (startDate && !endDate) return `Starts ${formatDateValue(startDate)}`;
+  if (!startDate && endDate) return `Ends ${formatDateValue(endDate)}`;
+  return `${formatDateValue(startDate)} – ${formatDateValue(endDate)}`;
+}
+
+function formatDateValue(value) {
+  const date = new Date(`${value}T12:00:00`);
+  return date.toLocaleDateString([], { month: "short", day: "numeric", year: "numeric" });
+}
+
+function formatSavedPlanTimestamp(value) {
+  const date = new Date(value);
+  return date.toLocaleString([], { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
+}
+
+function formatCareType(value) {
+  if (value === "emergency") return "Emergency care";
+  if (value === "urgent") return "Urgent care";
+  if (value === "routine") return "Routine care";
+  return "Care type unknown";
+}
+
+function buildSavedFacilityDirectionsUrl(facility) {
+  const destination = Number.isFinite(facility.lat) && Number.isFinite(facility.lng)
+    ? `${facility.lat},${facility.lng}`
+    : facility.address || facility.name;
+  return `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(destination)}`;
+}
+
+function prefersReducedMotion() {
+  return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+}


### PR DESCRIPTION
## What changed

- add a persistent active-plan summary directly below the mode and search panel whenever a valid saved plan exists
- show trip name, destination, dates, pet name, and last-updated time
- show visually distinct Primary and Backup facility cards
- add Call actions when a phone number is available
- add Directions actions for both facilities
- add Edit Plan and Clear Plan actions
- add a prominent Open Emergency Mode action that switches PawPath to the immediate-care view and emphasizes the saved emergency actions
- restore the summary from the existing localStorage plan after page load
- keep the summary synchronized after save, automatic updates, selection changes, and either Clear Plan path
- support cross-tab storage updates
- add compact responsive layouts for tablet and mobile widths
- announce edit, clear, and emergency-mode status changes accessibly

## Validation

- reviewed the branch diff against `main`
- confirmed the summary reads the existing `pawpath.activeCarePlan.v1` schema rather than creating a second data model
- confirmed Primary and Backup actions use the stored facility snapshots
- confirmed canceling Clear Plan does not falsely announce success
- confirmed the emergency-focused state resets when returning to Plan a Trip
- changes are limited to the summary module, its responsive styles, and the existing late-loading integration file

The repository has no automated browser-test suite, so saved-plan restoration, phone links, directions, clear confirmation, cross-tab updates, and mobile layout still require a deployed browser check.

Closes #8