### PR TITLE
Add ChatGPT Project package

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,10 @@ This directory contains the product definition and implementation guidance for e
 6. [Implementation Notes](IMPLEMENTATION_NOTES.md)
 7. [Demo Script](DEMO_SCRIPT.md)
 
+## ChatGPT Project package
+
+Use the [PawPath ChatGPT Project Setup](chatgpt-project/README.md) to create a dedicated long-running workspace with paste-ready project instructions, curated source files, current-state handoff, engineering workflow, and starter prompts.
+
 ## Current product objective
 
 Build `v0.2 – Care Plan POC` so a new viewer can understand within two minutes that PawPath is not merely a veterinarian map. It is a destination-based pet-care preparedness workflow with primary and backup facility selection, a saved care plan, Emergency Mode, and a printable emergency card.

--- a/docs/chatgpt-project/CURRENT_STATE.md
+++ b/docs/chatgpt-project/CURRENT_STATE.md
@@ -1,0 +1,147 @@
+# PawPath Current State
+
+Last updated: July 2026
+
+## Live application
+
+- Repository: `jeffthomasiii/pawpath`
+- Default branch: `main`
+- Live site: `https://jeffthomasiii.github.io/pawpath/`
+- Hosting: GitHub Pages
+
+## Current implemented capabilities
+
+### Mapping and search
+
+- Leaflet interactive map
+- OpenStreetMap tiles and facility records
+- Nominatim destination geocoding
+- Overpass veterinary-facility queries
+- Search by city, state, ZIP code, campground, or destination text supported by Nominatim
+- Browser geolocation through **Use my location**
+- Normal nearby search area of approximately 7.5 miles
+- Conditional emergency fallback search up to 30 miles when no emergency or urgent-care listing appears nearby
+- Explicit unresolved state when OpenStreetMap cannot identify an emergency facility
+- External Google Maps links for Directions and emergency search
+
+### Product modes
+
+- **Plan a Trip**
+  - destination-oriented search language
+  - trip-plan editor
+  - Primary and Backup selection controls
+  - save and update one active care plan
+- **Find Care Now**
+  - immediate-care language
+  - current-location emphasis
+  - planning editor and selection controls hidden
+- Saved-plan summary includes an emergency-focused transition, but the full Emergency Mode workflow remains the next major increment.
+
+### Facility evaluation
+
+- Facility details from cards and map markers
+- Emergency, urgent, routine, or unknown classification
+- Confidence states such as source-listed, likely emergency, and needs confirmation
+- Honest handling of missing phone, hours, website, and source details
+- OpenStreetMap source disclosure
+- Call-ahead safety language
+
+### Care-plan selection
+
+- One Primary emergency or urgent-care facility
+- One distinct Backup facility
+- Replace, move, view, and remove behavior
+- Selection indicators on cards, map markers, details, and summary
+
+### Active care-plan persistence
+
+- Storage key: `pawpath.activeCarePlan.v1`
+- One active plan in browser `localStorage`
+- Schema version, ID, created timestamp, and updated timestamp
+- Trip name and destination
+- Optional travel dates
+- Optional pet name, owner phone, and brief important note
+- Stored Primary and Backup facility snapshots
+- Restore after refresh
+- Validation and safe removal of malformed or unsupported stored data
+- Confirmed Clear Plan action
+- No backend or account
+
+### Persistent saved-plan summary
+
+- Appears when a valid saved plan exists
+- Trip name, destination, dates, pet, and updated time
+- Visually distinct Primary and Backup cards
+- Call actions where phone data exists
+- Directions actions
+- Edit Plan and Clear Plan
+- Open Emergency Mode action
+- Responsive desktop and mobile presentation
+- Cross-tab storage update handling
+
+## Current Phase 1 roadmap status
+
+Completed:
+
+- POC-01: Plan a Trip and Find Care Now modes
+- POC-02: Facility detail and confidence states
+- POC-03: Primary and Backup selection
+- POC-04: Persistent active care plan
+- POC-05: Persistent saved-plan summary
+
+Next:
+
+- POC-06: Full Emergency Mode
+
+Remaining after Emergency Mode:
+
+- POC-07: Curated demonstration data
+- POC-08: Printable emergency card
+- POC-09: Shareable POC validation
+
+## Important GitHub references
+
+- Phase 1 tracker: Issue #13
+- Full Emergency Mode: Issue #9
+- Curated demo data: Issue #10
+- Printable emergency card: Issue #11
+- Shareable POC validation: Issue #12
+
+## Technical architecture
+
+The proof of concept is a static application with no bundler or module system. JavaScript files share global state and several later files wrap functions defined by earlier files. Script order is therefore significant.
+
+Current major files include:
+
+- `index.html`
+- `styles.css`
+- `site-fixes.css`
+- `selection.css`
+- `care-plan.css`
+- `emergency-fallback.css`
+- `plan-summary.css`
+- `leaflet-local.css`
+- `app.js`
+- `emergency-fallback.js`
+- `selection.js`
+- `care-plan.js`
+- `plan-summary.js`
+- `map-layout-fix.js`
+
+## Known limitations and risks
+
+- No automated browser-test suite
+- No build or lint process
+- Public OpenStreetMap services are not production-scale infrastructure
+- Facility data may be incomplete, inconsistent, or outdated
+- Emergency capability is often inferred because source records lack explicit tags
+- Saved data exists only in the current browser
+- Clearing browser storage removes the plan
+- No offline map support yet
+- No user accounts, cloud sync, or multi-plan storage
+- Several modules wrap global functions; careless script-order changes can break behavior
+- Browser geolocation and remote API behavior require deployed or local-server testing
+
+## Immediate implementation objective
+
+Build a full Emergency Mode that is clearly different from ordinary Find Care Now. It should prioritize the saved Primary and Backup facilities, immediate Call and Directions actions, current-location relevance, and a minimal decision path during a stressful situation.

--- a/docs/chatgpt-project/ENGINEERING_WORKFLOW.md
+++ b/docs/chatgpt-project/ENGINEERING_WORKFLOW.md
@@ -1,0 +1,106 @@
+# PawPath Engineering Workflow
+
+## Purpose
+
+Use this workflow for code, documentation, bug fixes, and roadmap increments in the PawPath repository.
+
+## Before changing code
+
+1. Read the current issue and its acceptance criteria.
+2. Inspect the current `main` files involved in the feature.
+3. Review `CURRENT_STATE.md`, the roadmap, and implementation notes.
+4. Identify which existing global functions, state variables, DOM IDs, storage fields, and script-order dependencies the change touches.
+5. Confirm whether the request is a bug fix, roadmap increment, documentation task, or exploratory design decision.
+
+## Branch and pull-request pattern
+
+- Create one focused branch per increment or fix.
+- Suggested branch prefixes:
+  - `agent/feature-name`
+  - `agent/fix-name`
+  - `docs/topic-name`
+- Keep unrelated cleanup outside the branch unless it is required for the requested change.
+- Open a pull request that includes:
+  - what changed
+  - why it strengthens PawPath
+  - acceptance criteria addressed
+  - validation performed
+  - known limitations
+  - issue-closing reference
+- Merge only after GitHub reports the PR as mergeable.
+- Prefer squash merges for focused increments.
+
+## Static application constraints
+
+PawPath currently uses plain scripts rather than ES modules. Later scripts may wrap functions defined earlier. Always verify:
+
+- script loading order
+- duplicate global function names
+- DOMContentLoaded registration order
+- whether a function reference was captured before another module wrapped it
+- whether a new listener duplicates an existing listener
+- whether rerendering removes decorations or event handlers
+- whether map size must be invalidated after layout changes
+
+## HTML checks
+
+- New IDs must be unique.
+- JavaScript lookups must match exact HTML IDs.
+- Buttons need explicit `type="button"` unless they submit a form.
+- Form controls require labels.
+- Dynamic status messages should use an appropriate live region.
+- Dialog and focus behavior must work with keyboard navigation.
+- Avoid hiding critical content only by color.
+
+## CSS checks
+
+- Use existing PawPath tokens from `styles.css`.
+- Do not invent token names without adding them to `:root`.
+- Test desktop, tablet, and narrow mobile layouts conceptually and in a browser when possible.
+- Preserve visible focus states.
+- Respect reduced-motion preferences for scrolling or animation.
+- Verify that new content does not destabilize Leaflet’s map dimensions.
+
+## JavaScript checks
+
+- Fail safely when remote APIs or browser storage are unavailable.
+- Do not silently label routine care as emergency care.
+- Treat source data as incomplete unless evidence supports a stronger claim.
+- Sanitize dynamic content inserted with `innerHTML`.
+- Validate stored data before restoring it.
+- Keep storage schema versioned.
+- Avoid storing unnecessary sensitive information.
+- Confirm that saved state, rendered state, and map state remain synchronized after rerenders.
+
+## Data-source rules
+
+- OpenStreetMap attribution must remain visible.
+- Public Nominatim and Overpass usage must remain lightweight.
+- Do not implement bulk downloads, aggressive polling, or high-volume automated calls.
+- Emergency classification should retain confidence language and call-ahead guidance.
+- Google Maps is permitted only as an external link destination in the current architecture.
+
+## Minimum validation for each increment
+
+Perform and report the checks that are actually possible:
+
+- Review complete branch diff against `main`.
+- Check changed filenames and scope.
+- Review script order and shared global dependencies.
+- Check DOM IDs referenced by new JavaScript.
+- Check CSS variable names against the design tokens.
+- Check storage schema compatibility when relevant.
+- Check fallback and error states.
+- Check accessible names, focus targets, and live-region messages.
+- Identify browser interactions that remain untested.
+
+Do not claim automated, live-browser, mobile-device, geolocation, API, or deployment testing unless it was actually performed.
+
+## After merge
+
+1. Confirm the issue closed when the PR used `Closes #…`.
+2. Update Issue #13, the Phase 1 tracker.
+3. Update README current capabilities and next task when materially changed.
+4. Update `CURRENT_STATE.md` after significant increments.
+5. Tell the user what to test on the deployed GitHub Pages site.
+6. Note that GitHub Pages and browser caches may require a short wait and force refresh.

--- a/docs/chatgpt-project/PROJECT_BRIEF.md
+++ b/docs/chatgpt-project/PROJECT_BRIEF.md
@@ -1,0 +1,87 @@
+# PawPath Project Brief
+
+## One-sentence product definition
+
+PawPath is a mobile-friendly pet-care preparedness tool that helps people traveling with pets identify, evaluate, save, and quickly act on veterinary and emergency-care options near a destination.
+
+## Why PawPath exists
+
+A general map can show nearby veterinary businesses, but it does not create a travel-specific care plan. Travelers must still determine which facility is appropriate, whether emergency care is actually available, what the backup option should be, how far care is from the destination, and what information should be saved before entering an unfamiliar or low-connectivity area.
+
+PawPath is designed around that missing preparedness and emergency-readiness workflow.
+
+> Google Maps and Apple Maps help people find places. PawPath helps people traveling with pets make a care plan and act quickly when something goes wrong.
+
+## Primary users
+
+- Campers traveling with dogs, cats, or other pets
+- RV travelers
+- Road-trippers
+- People staying in unfamiliar towns or rural destinations
+- Pet owners who want emergency-care options prepared before leaving home
+
+## Primary jobs to be done
+
+### Before a trip
+
+- Search around a campground, destination, city, or ZIP code
+- Understand what care options exist nearby
+- Identify one Primary emergency or urgent-care facility
+- Identify a distinct Backup facility
+- Save trip and pet details in one place
+- Prepare a portable or printable emergency reference
+
+### During an urgent situation
+
+- Reach the saved plan quickly
+- Call the Primary facility
+- Start directions
+- Switch to the Backup when necessary
+- Use current-location search when the saved plan is not relevant
+- Reduce unnecessary choices and reading
+
+## Core workflows
+
+### Plan a Trip
+
+A preparation workflow centered on destination search, facility evaluation, Primary and Backup selection, trip details, and saving one active care plan.
+
+### Find Care Now
+
+An immediate-action workflow centered on current location, emergency prioritization, Call, Directions, and rapid access to saved Primary and Backup options.
+
+### Emergency Mode
+
+The focused urgent-use state of Find Care Now. It should minimize planning controls and place immediate actions first.
+
+## Current proof-of-concept promise
+
+PawPath should help a user create a destination-based care plan in under three minutes and reach emergency actions in under thirty seconds.
+
+## Trust and safety boundaries
+
+PawPath is not:
+
+- a veterinary diagnosis tool
+- a medical-triage service
+- a guarantee that a facility is open or available
+- a guarantee that a facility treats a particular species or condition
+- a complete or verified national veterinary database
+
+PawPath should consistently encourage users to call ahead and confirm services and availability.
+
+## Privacy boundary
+
+The proof of concept stores one active care plan in the current browser. It should not request or store medical records, identification documents, payment data, or unnecessary sensitive information.
+
+## Product success for v0.2
+
+The proof of concept is ready to share when:
+
+- A new viewer understands why PawPath is different from a general map search
+- A destination-based plan can be created quickly
+- Primary and Backup facilities persist after refresh
+- Emergency Mode provides direct Call, Directions, and Backup actions
+- Curated demo data supports a reliable walkthrough
+- A printable emergency card works cleanly
+- The experience functions well on desktop and mobile

--- a/docs/chatgpt-project/PROJECT_INSTRUCTIONS.md
+++ b/docs/chatgpt-project/PROJECT_INSTRUCTIONS.md
@@ -1,0 +1,97 @@
+# PawPath ChatGPT Project Instructions
+
+Paste the content below into **Project settings → Project instructions** for the PawPath ChatGPT Project.
+
+---
+
+You are the product strategist, UX partner, technical planner, documentation writer, and implementation assistant for **PawPath**.
+
+PawPath is a mobile-friendly pet-care preparedness web application for campers, RV travelers, road-trippers, and other people traveling with pets. Its purpose is not simply to reproduce a “veterinarian near me” search. PawPath helps users identify, evaluate, select, save, and act on veterinary and emergency-care options before and during a trip.
+
+## Core product distinction
+
+Google Maps and Apple Maps help people find places. PawPath helps people traveling with pets make a care plan and act quickly when something goes wrong.
+
+The product should make this distinction obvious through two workflows:
+
+- **Plan a Trip:** search a destination, review care options, choose Primary and Backup facilities, enter trip and pet details, save the plan, and prepare before leaving.
+- **Find Care Now / Emergency Mode:** use current location or the saved plan to surface immediate Call, Directions, Primary, and Backup actions with minimal decision-making.
+
+## Product principles
+
+1. Preparedness before urgency.
+2. Reduce confusion during stressful moments.
+3. Be honest about incomplete or uncertain facility data.
+4. Never present PawPath as veterinary diagnosis, medical triage, or a guarantee of availability.
+5. Encourage users to call ahead and confirm services, hours, species accepted, and availability.
+6. Prefer simple, mobile-first workflows over feature density.
+7. Keep the proof of concept lightweight, understandable, and shareable.
+8. Protect privacy. Avoid collecting or storing unnecessary sensitive data.
+9. Treat accessibility, keyboard support, responsive behavior, and clear language as required product features.
+10. Preserve the established PawPath visual system: deep forest green, sage, warm amber, off-white surfaces, restrained danger red, rounded cards, and a calm outdoors-oriented tone.
+
+## Current technical constraints
+
+- Static HTML, CSS, and vanilla JavaScript hosted with GitHub Pages.
+- Leaflet for mapping.
+- OpenStreetMap tiles and facility data.
+- Nominatim for geocoding.
+- Overpass API for veterinary facility searches.
+- Browser `localStorage` for one active care plan.
+- No backend, user accounts, paid map API, or build process in the current proof of concept.
+- Google Maps may be used only as an external destination for Directions or emergency-search links.
+- Public OpenStreetMap services are appropriate only for a lightweight proof of concept and must not be treated as unlimited production infrastructure.
+
+## Repository and development workflow
+
+Repository: `jeffthomasiii/pawpath`
+
+When asked to modify the application:
+
+1. Read the relevant project sources and current GitHub issue before changing code.
+2. Confirm the current `main` implementation instead of relying on stale assumptions.
+3. Create a focused feature or fix branch.
+4. Keep each increment tied to one roadmap issue whenever practical.
+5. Preserve existing working behavior unless the requested change explicitly replaces it.
+6. Prefer small, clearly separated JavaScript and CSS modules over unnecessary rewrites.
+7. Review script loading order because several modules wrap or extend shared global functions.
+8. Check HTML IDs, CSS token names, local-storage schema compatibility, map resizing, and responsive behavior.
+9. Open a pull request with a concrete summary, validation notes, limitations, and the issue-closing reference.
+10. Merge only after GitHub reports the pull request as mergeable.
+11. Update the Phase 1 tracking issue and README when an increment changes current capabilities or the next task.
+
+## Response and decision style
+
+- Be direct, concrete, and honest.
+- Do not overstate testing. The repository currently has no automated browser-test suite.
+- Clearly distinguish confirmed behavior, static review, inference, and items that still need deployed browser testing.
+- Avoid generic product advice when a decision can be grounded in the PawPath vision, roadmap, source files, or live implementation.
+- When proposing features, explain how they strengthen the “Why PawPath?” distinction.
+- Prefer one recommended direction over a long list of equal options, while noting meaningful tradeoffs.
+- Maintain concise but complete GitHub issues, pull-request descriptions, release notes, and documentation.
+
+## Source-of-truth priority
+
+When sources disagree, use this order:
+
+1. Current `main` branch code
+2. Active GitHub issues and the v0.2 tracking issue
+3. `docs/chatgpt-project/CURRENT_STATE.md`
+4. Product vision, POC scope, roadmap, and implementation notes
+5. README
+6. Older chats or historical assumptions
+
+## Immediate roadmap
+
+The current Phase 1 objective is `v0.2 – Care Plan POC`.
+
+The remaining sequence is:
+
+1. Full Emergency Mode
+2. Curated demonstration data
+3. Printable emergency card
+4. Shareable POC validation
+
+Do not skip directly to accounts, cloud synchronization, monetization, native mobile apps, or production-scale infrastructure unless the user explicitly changes the roadmap.
+
+---

--- a/docs/chatgpt-project/README.md
+++ b/docs/chatgpt-project/README.md
@@ -1,0 +1,75 @@
+# PawPath ChatGPT Project Setup
+
+This folder contains the durable context package for a dedicated PawPath ChatGPT Project.
+
+## Recommended setup
+
+### 1. Create the project
+
+In ChatGPT:
+
+1. Select **New project** in the sidebar.
+2. Name it **PawPath Product & Development**.
+3. Choose a forest-green color and a paw or map-style icon.
+4. Choose **Project-only memory** when the option is presented.
+
+Project-only memory keeps the workspace focused on PawPath chats, instructions, and files.
+
+### 2. Add project instructions
+
+Open the project menu, select **Project settings**, and paste the instruction block from:
+
+- [`PROJECT_INSTRUCTIONS.md`](PROJECT_INSTRUCTIONS.md)
+
+Project instructions apply only inside the PawPath Project and take precedence over global custom instructions there.
+
+### 3. Add project sources
+
+Start with the ten required sources listed in:
+
+- [`SOURCE_MANIFEST.md`](SOURCE_MANIFEST.md)
+
+The first three are the most important handoff files:
+
+- [`PROJECT_BRIEF.md`](PROJECT_BRIEF.md)
+- [`CURRENT_STATE.md`](CURRENT_STATE.md)
+- [`ENGINEERING_WORKFLOW.md`](ENGINEERING_WORKFLOW.md)
+
+Then add the existing product and roadmap documents from the parent `docs` folder.
+
+### 4. Move relevant chats
+
+Move the active PawPath development conversation into the new project so its decisions and implementation history remain available alongside the curated sources.
+
+Avoid moving unrelated mapping, branding, or other product conversations unless they directly inform PawPath.
+
+### 5. Connect GitHub during implementation chats
+
+Use the connected GitHub repository as the current implementation source:
+
+- `jeffthomasiii/pawpath`
+
+Uploaded project files provide stable context, but current `main`, active issues, and pull requests should determine the actual implementation state.
+
+### 6. Start focused conversations
+
+Use separate chats for product strategy, feature implementation, bugs, UX, data trust, and release readiness.
+
+Suggested starting prompts are in:
+
+- [`STARTER_PROMPTS.md`](STARTER_PROMPTS.md)
+
+## Package contents
+
+| File | Purpose |
+|---|---|
+| `PROJECT_INSTRUCTIONS.md` | Paste-ready ChatGPT Project instructions |
+| `PROJECT_BRIEF.md` | Concise product definition and success criteria |
+| `CURRENT_STATE.md` | Current implementation, roadmap status, architecture, and limitations |
+| `ENGINEERING_WORKFLOW.md` | Branch, PR, validation, and documentation workflow |
+| `SOURCE_MANIFEST.md` | Required and optional project sources |
+| `STARTER_PROMPTS.md` | Reusable prompts for common PawPath workflows |
+
+## Maintenance rule
+
+After each major merged increment, update `CURRENT_STATE.md` and replace or refresh that source in the ChatGPT Project. Keep the project package concise; durable decisions are more useful than uploading every transcript.

--- a/docs/chatgpt-project/SOURCE_MANIFEST.md
+++ b/docs/chatgpt-project/SOURCE_MANIFEST.md
@@ -1,0 +1,79 @@
+# PawPath ChatGPT Project Source Manifest
+
+## Recommended project name
+
+**PawPath Product & Development**
+
+## Recommended project memory
+
+Choose **Project-only memory** when creating the ChatGPT Project so PawPath work remains anchored to this project’s chats, instructions, and sources rather than unrelated conversations.
+
+## Required sources
+
+Add these first:
+
+1. `PROJECT_BRIEF.md`
+   - concise product definition, audience, workflows, success criteria, and safety boundaries
+2. `CURRENT_STATE.md`
+   - implementation handoff, current roadmap status, architecture, and known limitations
+3. `ENGINEERING_WORKFLOW.md`
+   - repository workflow, coding constraints, validation expectations, and merge process
+4. `../WHY_PAWPATH.md`
+   - complete product positioning and competitive distinction
+5. `../PRODUCT_VISION.md`
+   - mission, jobs to be done, principles, and product direction
+6. `../POC_SCOPE.md`
+   - proof-of-concept requirements and release criteria
+7. `../ROADMAP.md`
+   - phased development plan
+8. `../IMPLEMENTATION_NOTES.md`
+   - state, storage, data, confidence, and architecture guidance
+9. `../PHASE_1_RELEASE_PLAN.md`
+   - increments and release gate
+10. `../../README.md`
+   - public repository overview and current capabilities
+
+## Optional sources
+
+Add these when useful:
+
+- `STARTER_PROMPTS.md`
+- `../DEMO_SCRIPT.md`
+- `../BACKLOG.md`
+- `../ISSUE_TEMPLATES.md`
+- selected screenshots of the current desktop and mobile interface
+- saved ChatGPT responses that capture important product decisions
+
+## GitHub as the live source of truth
+
+The uploaded Markdown files provide durable context, but current implementation questions should also use the connected GitHub repository because code and issues may change after the files were uploaded.
+
+Important live references:
+
+- Repository: `jeffthomasiii/pawpath`
+- Phase 1 tracker: Issue #13
+- Current next issue: Issue #9, Full Emergency Mode
+
+## Keeping project sources current
+
+After each significant merged increment:
+
+1. Update `CURRENT_STATE.md` in the repository.
+2. Update the README when public capabilities or the next task change.
+3. Replace the old uploaded `CURRENT_STATE.md` in the ChatGPT Project, or save the updated content as a new project source.
+4. Save important decision responses to the project sources when they establish lasting product direction.
+5. Avoid uploading every implementation chat; keep durable decisions and concise handoffs instead.
+
+## Suggested project organization
+
+Use separate chats for:
+
+- Product strategy and roadmap
+- Current feature implementation
+- Bugs and QA
+- UX and interface design
+- Data sources and trust
+- Documentation and release notes
+- Future architecture and production planning
+
+This keeps individual conversations focused while allowing the Project to retain shared files and context.

--- a/docs/chatgpt-project/STARTER_PROMPTS.md
+++ b/docs/chatgpt-project/STARTER_PROMPTS.md
@@ -1,0 +1,43 @@
+# PawPath ChatGPT Project Starter Prompts
+
+Use these prompts to begin focused chats inside the PawPath ChatGPT Project.
+
+## Resume development
+
+> Review the PawPath project sources, current `main` branch, Issue #13, and the next open Phase 1 issue. Summarize the current state, identify any conflicts between documentation and code, and recommend the smallest complete next increment. Do not modify the repository until the implementation plan is clear.
+
+## Implement the next roadmap increment
+
+> Implement the next PawPath Phase 1 increment from its GitHub issue. Read the current code and project sources first, create a focused branch, preserve existing behavior, validate shared globals and script order, open a PR with honest validation notes, merge only when GitHub reports it mergeable, and update the tracker and README.
+
+## Investigate a bug
+
+> Investigate this PawPath bug end to end: [describe bug]. Check the current `main` implementation and deployed behavior where possible. Find the underlying cause rather than repeatedly patching presentation symptoms. Explain the cause briefly, implement a focused fix on a branch, and state what still requires browser testing.
+
+## Product decision
+
+> Evaluate this PawPath product decision against the Why PawPath positioning, primary users, Plan a Trip workflow, Emergency Mode, privacy boundary, and v0.2 release goal: [decision]. Recommend one direction, explain the tradeoffs, and identify whether it belongs in the current POC or a later phase.
+
+## UX review
+
+> Review the current PawPath interface for clarity, mobile usability, accessibility, and whether the difference between Plan a Trip and Find Care Now is obvious. Prioritize the most consequential issues and propose a practical implementation sequence without expanding the v0.2 scope unnecessarily.
+
+## Emergency Mode planning
+
+> Design the PawPath Emergency Mode increment using Issue #9, the saved-plan summary, current-location search, and the existing Primary and Backup data. Define the user flow, visual hierarchy, state changes, edge cases, accessibility behavior, and acceptance criteria before writing code.
+
+## Data and trust review
+
+> Review PawPath’s facility sourcing and emergency-classification approach. Separate what OpenStreetMap explicitly confirms from what PawPath infers. Identify misleading states, missing confidence language, and responsible fallback behavior. Keep recommendations appropriate for a lightweight proof of concept.
+
+## Release readiness
+
+> Evaluate PawPath against the v0.2 release gate. Review the current code, Issues #9–#12, README, POC scope, and release plan. Produce a pass/fail checklist, identify blockers, and recommend the exact work order needed to make the POC shareable.
+
+## Documentation update
+
+> Update PawPath documentation after the latest merged increment. Ensure README current capabilities, next task, `CURRENT_STATE.md`, roadmap status, and Issue #13 agree with the current `main` branch. Do not describe features that are not actually implemented.
+
+## Future architecture exploration
+
+> Explore the likely production architecture for PawPath after the v0.2 POC, but do not modify the current roadmap. Compare options for facility data, verification, offline support, route planning, accounts, privacy, and scalable map infrastructure. Clearly separate near-term POC needs from later production decisions.


### PR DESCRIPTION
## What changed

- added a dedicated `docs/chatgpt-project` package for the long-running PawPath ChatGPT workspace
- added paste-ready Project instructions
- added a concise product brief
- added a current-state technical and roadmap handoff
- added an engineering workflow for branches, pull requests, validation, and documentation updates
- added a source manifest with the recommended files and maintenance process
- added reusable starter prompts for implementation, bugs, UX, strategy, release readiness, and future architecture
- added a complete ChatGPT Project setup guide
- linked the package from the main documentation index

## Why

PawPath now has enough product, UX, technical, roadmap, and data-trust context that a dedicated ChatGPT Project will provide better continuity than one long conversation. The repository remains the durable source of truth while the Project instructions and curated files keep future chats focused.

## Validation

- reviewed the complete package against the current `main` capabilities and Issue #13
- confirmed the current next roadmap item is Issue #9, Full Emergency Mode
- confirmed the package distinguishes stable uploaded context from live GitHub code and issues
- confirmed the source list remains within current Plus project file limits
- no application runtime files were changed