### PR TITLE
Apply approved PawPath brand system

### DIFF
--- a/brand-refresh.css
+++ b/brand-refresh.css
@@ -1,0 +1,392 @@
+/* PawPath approved brand layer: calm, product-first, and action-ready. */
+
+:root {
+  --forest-950: #273f39;
+  --forest-900: #2f4b43;
+  --forest-800: #3f6258;
+  --forest-700: #5f7f73;
+  --sage-100: #dce6df;
+  --sage-50: #eef3ef;
+  --sand-50: #faf9f6;
+  --sand-100: #f3f1ec;
+  --amber-500: #d8b58a;
+  --ink-900: #37424a;
+  --ink-700: #566269;
+  --ink-500: #737d81;
+  --danger: #b85f50;
+  --border: #d8ded8;
+  --shadow-sm: 0 6px 18px rgba(47, 75, 67, 0.06);
+  --shadow-md: 0 14px 34px rgba(47, 75, 67, 0.1);
+  --radius-sm: 10px;
+  --radius-md: 16px;
+  --radius-lg: 24px;
+}
+
+body {
+  background: var(--sand-50);
+  color: var(--ink-900);
+}
+
+.site-header {
+  padding: 22px 0 18px;
+}
+
+.brand-logo {
+  width: clamp(184px, 17vw, 238px);
+  filter: saturate(0.72) brightness(1.08);
+}
+
+.brand-tagline {
+  color: var(--ink-700);
+  font-weight: 600;
+}
+
+.status-badge,
+.result-count {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--forest-800);
+  box-shadow: none;
+}
+
+.hero-panel {
+  align-items: center;
+  border: 1px solid var(--border);
+  background:
+    radial-gradient(circle at 88% 12%, rgba(216, 181, 138, 0.2), transparent 30%),
+    linear-gradient(135deg, #eef3ef 0%, #f7f5f0 62%, #f3f1ec 100%);
+  color: var(--ink-900);
+  box-shadow: var(--shadow-sm);
+}
+
+.hero-panel::after {
+  border-color: rgba(47, 75, 67, 0.08);
+}
+
+.hero-copy h1 {
+  color: var(--forest-950);
+}
+
+.hero-copy > p:last-child,
+.mode-guidance,
+.form-message {
+  color: var(--ink-700);
+}
+
+.eyebrow {
+  color: var(--forest-700);
+  letter-spacing: 0.1em;
+}
+
+.mode-selector {
+  border-color: rgba(47, 75, 67, 0.12);
+  background: rgba(255, 255, 255, 0.52);
+  backdrop-filter: blur(10px);
+}
+
+.mode-option {
+  color: var(--ink-700);
+}
+
+.mode-option:hover {
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--forest-950);
+}
+
+.mode-option.is-active {
+  border-color: var(--border);
+  background: var(--white);
+  color: var(--forest-950);
+  box-shadow: 0 5px 14px rgba(47, 75, 67, 0.07);
+}
+
+.mode-option.is-active .mode-option-icon {
+  border-color: rgba(47, 75, 67, 0.14);
+  background: var(--sage-50);
+  color: var(--forest-900);
+}
+
+.search-card {
+  border-color: rgba(47, 75, 67, 0.12);
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 8px 24px rgba(47, 75, 67, 0.06);
+  backdrop-filter: blur(10px);
+}
+
+.input-wrap,
+.care-plan-field input,
+.care-plan-field textarea {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--ink-900);
+  box-shadow: none;
+}
+
+.button {
+  border-radius: var(--radius-sm);
+  font-weight: 750;
+  transition: background 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.button:hover {
+  transform: none;
+}
+
+.button-primary {
+  border-color: #cda779;
+  background: var(--amber-500);
+  color: #27352f;
+  box-shadow: none;
+}
+
+.button-primary:hover {
+  background: #cfaa7d;
+  box-shadow: 0 5px 14px rgba(47, 75, 67, 0.08);
+}
+
+.button-secondary,
+.hero-panel[data-mode="now"] #search-btn {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.78);
+  color: var(--forest-900);
+}
+
+.button-secondary:hover,
+.hero-panel[data-mode="now"] #search-btn:hover {
+  background: var(--white);
+}
+
+.hero-panel[data-mode="now"] {
+  background:
+    radial-gradient(circle at 88% 12%, rgba(216, 181, 138, 0.23), transparent 31%),
+    linear-gradient(135deg, #e8eee9, #f3f1ec);
+}
+
+.hero-panel[data-mode="now"] #loc-btn {
+  border-color: #cda779;
+  background: var(--amber-500);
+  color: #27352f;
+}
+
+.button:focus-visible,
+.filter-chip:focus-visible,
+.clinic-card:focus-visible,
+.mode-option:focus-visible,
+a:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline: 3px solid rgba(95, 127, 115, 0.46);
+  outline-offset: 3px;
+}
+
+.care-plan-editor,
+.care-plan-selection,
+.saved-plan-summary {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: var(--shadow-sm);
+}
+
+.care-plan-editor,
+.care-plan-selection {
+  border-radius: var(--radius-lg);
+}
+
+.care-plan-privacy-note,
+.source-disclosure,
+.call-ahead-note {
+  border-color: var(--border);
+  background: var(--sage-50);
+}
+
+.selection-slots {
+  gap: 12px;
+}
+
+.selection-slot,
+.saved-facility-card {
+  border-color: var(--border);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.76);
+  box-shadow: none;
+}
+
+.selection-slot.is-filled,
+.saved-facility-card.is-primary {
+  border-color: rgba(95, 127, 115, 0.48);
+  background: var(--sage-50);
+}
+
+.saved-facility-card.is-backup {
+  border-color: rgba(216, 181, 138, 0.62);
+  background: #fbf8f3;
+}
+
+.selection-role-label,
+.detail-badge,
+.care-badge {
+  border: 1px solid var(--border);
+  background: var(--sage-50);
+  color: var(--forest-800);
+}
+
+.selection-role-label.is-primary {
+  background: var(--sage-100);
+  color: var(--forest-950);
+}
+
+.selection-role-label.is-backup {
+  background: #f4e8d9;
+  color: #765b39;
+}
+
+.discovery-layout {
+  border-color: var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--white);
+  box-shadow: var(--shadow-sm);
+}
+
+.results-panel {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.94);
+}
+
+.filter-chip {
+  min-height: 38px;
+  border-radius: 10px;
+  background: transparent;
+}
+
+.filter-chip.is-active {
+  border-color: var(--forest-700);
+  background: var(--sage-100);
+  color: var(--forest-950);
+}
+
+.clinic-list {
+  gap: 0;
+  padding-right: 0;
+}
+
+.clinic-card {
+  border-width: 0 0 1px;
+  border-color: var(--border);
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.clinic-card:first-child {
+  border-top: 1px solid var(--border);
+}
+
+.clinic-card:hover,
+.clinic-card.is-selected {
+  border-color: var(--border);
+  background: var(--sage-50);
+  box-shadow: inset 3px 0 0 var(--forest-700);
+  transform: none;
+}
+
+.care-badge.is-emergency {
+  border-color: rgba(184, 95, 80, 0.24);
+  background: #f7e9e6;
+  color: #954b40;
+}
+
+.map-panel {
+  background: var(--mist, #e8eee9);
+}
+
+.map-note {
+  border-color: rgba(47, 75, 67, 0.12);
+  background: rgba(250, 249, 246, 0.93);
+  box-shadow: 0 5px 16px rgba(47, 75, 67, 0.08);
+}
+
+.custom-marker {
+  background: var(--forest-800);
+  box-shadow: 0 5px 14px rgba(47, 75, 67, 0.24);
+}
+
+.custom-marker.is-emergency {
+  background: var(--danger);
+}
+
+.facility-detail {
+  border-color: var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--sand-50);
+  box-shadow: -12px 0 36px rgba(47, 75, 67, 0.16);
+}
+
+.facility-detail::backdrop {
+  background: rgba(39, 63, 57, 0.34);
+}
+
+.facility-plan-selection,
+.facility-facts > div {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.icon-button {
+  border-color: var(--border);
+  background: var(--sage-50);
+  color: var(--forest-900);
+}
+
+.plan-role-button,
+.detail-action-secondary,
+.saved-facility-action {
+  border-color: var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--white);
+  color: var(--forest-900);
+}
+
+.saved-plan-summary {
+  border-radius: var(--radius-lg);
+  background: linear-gradient(180deg, var(--sage-50), var(--white));
+}
+
+.saved-plan-summary.is-emergency-active {
+  border-color: rgba(184, 95, 80, 0.34);
+  background: linear-gradient(180deg, #f8eeeb, var(--white));
+  box-shadow: 0 12px 30px rgba(184, 95, 80, 0.08);
+}
+
+.saved-plan-emergency-button {
+  border-color: var(--forest-800);
+  background: var(--forest-800);
+  color: var(--white);
+}
+
+.saved-plan-emergency-button:hover,
+.saved-plan-emergency-button:focus-visible {
+  background: var(--forest-950);
+}
+
+.text-button.is-destructive,
+.is-destructive {
+  color: var(--danger);
+}
+
+@media (max-width: 780px) {
+  .hero-panel {
+    border-radius: 18px;
+  }
+
+  .discovery-layout,
+  .care-plan-editor,
+  .care-plan-selection,
+  .saved-plan-summary {
+    border-radius: 18px;
+  }
+
+  .brand-logo {
+    width: 166px;
+  }
+}

--- a/docs/BRAND_GUIDE.md
+++ b/docs/BRAND_GUIDE.md
@@ -1,0 +1,287 @@
+# PawPath Brand Guide
+
+## Purpose
+
+This guide is the durable brand source for PawPath product design, UX writing, documentation, demonstrations, and ChatGPT-assisted feature planning.
+
+PawPath is a calm preparedness companion for people traveling with pets. The brand should help users feel organized and capable before a trip and reduce decision-making during an urgent situation.
+
+## Brand foundation
+
+### Product category
+
+**Pet-care preparedness for the road.**
+
+### Brand promise
+
+**Travel with a care plan.**
+
+### Core idea
+
+**Preparedness that travels with you.**
+
+### Creative direction
+
+**Trail guide, not alert siren.**
+
+PawPath combines the steadiness of outdoor wayfinding with practical pet-care preparation. It should feel calm, trustworthy, useful, and road-ready without appearing clinical, rustic, childish, or alarmist.
+
+### Product distinction
+
+General maps help people find places. PawPath helps people traveling with pets make a care plan and act quickly when something goes wrong.
+
+Every significant feature, message, and visual decision should strengthen that distinction.
+
+## Audience
+
+The primary audience includes campers, RV travelers, road-trippers, and people staying with pets in unfamiliar or rural destinations.
+
+Before a trip, users want reassurance without fear-based messaging. During an urgent situation, they need fast scanning, obvious actions, and fewer decisions.
+
+## Brand personality
+
+PawPath is:
+
+- calm
+- prepared
+- trustworthy
+- practical
+- caring
+- clear
+- road-ready
+
+Prefer reassuring over alarmist, practical over clever, warm over cute, capable over clinical, transparent over authoritative-sounding, and focused over feature-dense.
+
+## Voice and tone
+
+PawPath uses plainspoken, calm, direct, and honest language.
+
+### Writing rules
+
+- Lead with outcomes and next actions.
+- Use short sentences and familiar words.
+- Put the most important action first.
+- Explain uncertainty plainly.
+- State what information is missing rather than hiding it.
+- Use sentence case for headings and controls.
+- Keep urgent action labels short.
+- Avoid jokes, puns, pet baby-talk, hype, and fear-based language.
+- Never imply diagnosis, medical triage, guaranteed availability, or guaranteed suitability.
+
+### Preferred vocabulary
+
+Use:
+
+- care plan
+- Primary
+- Backup
+- care option
+- veterinary facility
+- source listed
+- likely emergency
+- needs confirmation
+- call ahead
+- destination
+- current location
+- saved on this device
+
+Avoid:
+
+- guaranteed
+- best veterinarian
+- safest clinic
+- instant emergency help
+- diagnosis
+- triage
+- perfect match
+- lifesaving app
+
+### Calls to action
+
+Planning:
+
+- Explore destination
+- Choose Primary
+- Choose Backup
+- Save care plan
+
+Immediate care:
+
+- Call Primary
+- Start directions
+- Use Backup
+- View pet details
+
+Trust and uncertainty:
+
+- Call to confirm
+- Check source details
+
+## Visual system
+
+### Logo
+
+Preserve the established PawPath mark and wordmark geometry:
+
+- paw-shaped destination mark
+- winding travel path
+- veterinary location marker
+- two-part PawPath wordmark
+
+Do not replace the logo with a generic paw, map pin, shield, medical cross, or newly invented symbol. Color variants may be created for accessibility and different backgrounds, but the original identity should remain recognizable.
+
+### Approved color palette
+
+| Token | Hex | Purpose |
+|---|---:|---|
+| Pine | `#2F4B43` | Main brand anchor, headings, strong actions |
+| Pine deep | `#273F39` | Highest-emphasis text and dark framing |
+| Pine soft | `#5F7F73` | Secondary emphasis and selected states |
+| Sage | `#AFC3B3` | Supporting brand color and gentle highlights |
+| Mist | `#E8EEE9` | Informational and selected surfaces |
+| Stone | `#F3F1EC` | Warm neutral surfaces |
+| Canvas | `#FAF9F6` | Primary page background |
+| Amber | `#D8B58A` | Primary action and route emphasis |
+| Ink | `#37424A` | Primary body text |
+| Ink soft | `#566269` | Secondary text |
+| Danger | `#B85F50` | Destructive actions and genuine blocking warnings |
+| Border | `#D8DED8` | Quiet structure and dividers |
+
+### Color behavior
+
+Color supports the task; it is not the task.
+
+- Use Canvas, Stone, White, and Mist for most surfaces.
+- Use Pine for hierarchy and trust.
+- Use Amber for the next useful action, not general decoration.
+- Use Danger sparingly.
+- Emergency Mode should remain Pine-led rather than becoming a red screen.
+- Never rely on color alone for role, confidence, urgency, or selection.
+
+### Typography
+
+Use Inter or the system sans-serif stack for the proof of concept.
+
+- Headlines should be short, confident, and easy to scan.
+- Body text should prioritize mobile readability.
+- Use weight and spacing before adding color.
+- Reserve all caps for small eyebrow labels.
+
+## UI shape strategy
+
+Cards and rounded rectangles are tools, not the complete PawPath design language.
+
+Use a mixed system:
+
+### Open sections
+
+Best for orientation, page headings, mode context, search, and explanatory content. Open layouts feel calmer and keep the product task in focus.
+
+### Light cards
+
+Best for saved plans, Primary and Backup decisions, facility details, call-ahead guidance, and emergency information. Use cards when a user needs a clear decision or action boundary.
+
+### List rows
+
+Best for facility results, short facts, and scan-heavy content. Prefer dividers and selected-row emphasis over a stack of individually elevated cards.
+
+### Drawers and sheets
+
+Best for facility detail, confirmations, and focused secondary tasks. They should preserve context without overloading the primary screen.
+
+### Shape rules
+
+- Controls: approximately 8–12px corner radius
+- Cards and focused panels: approximately 12–20px corner radius
+- Major page groups: up to approximately 24px when the boundary is meaningful
+- Use minimal shadows
+- Prefer dividers over boxes when possible
+- Avoid bubbly, toy-like, or excessively pill-shaped controls
+- Use pills only for compact filters and status labels
+
+## Product application
+
+### Plan a Trip
+
+The planning experience should feel open, calm, and guided. Use light surfaces, a clear destination search, and selective emphasis around Primary, Backup, and save actions.
+
+### Facility results
+
+Results should optimize scanability. Use rows, quiet dividers, compact confidence language, and a clear selected state. Avoid making every result look like a promoted card.
+
+### Saved care plan
+
+The saved plan should resemble a dependable travel reference rather than a promotional panel. Primary and Backup need clear hierarchy without loud color blocking.
+
+### Emergency Mode
+
+Emergency Mode is the most focused expression of the brand:
+
+- Primary first
+- Call and Directions prominent
+- Backup immediately available
+- minimal unrelated controls
+- visible call-ahead guidance
+- no diagnosis or treatment advice
+- calm Pine framing with restrained Amber action emphasis
+
+### Printable emergency card
+
+The printable card should be practical, compact, grayscale-safe, and legible. It should include the PawPath identity, Primary and Backup, phone numbers, addresses, pet and owner details, generated date, and call-ahead disclaimer.
+
+## Accessibility and trust
+
+Accessibility is part of the brand.
+
+- Preserve visible keyboard focus.
+- Maintain readable contrast.
+- Do not hide critical content in color, icons, hover, or maps alone.
+- Keep touch targets comfortable on mobile.
+- Respect reduced-motion preferences.
+- Keep source and confidence language understandable.
+- Protect privacy and avoid collecting unnecessary sensitive information.
+
+## Feature decision filter
+
+Before recommending or designing a feature, ask:
+
+1. Does it help a traveler prepare before care is needed?
+2. Does it reduce confusion during an urgent situation?
+3. Does it improve confidence without overstating certainty?
+4. Does it address a pet-travel need that general maps do not organize well?
+5. Can its value be demonstrated clearly in the current product story?
+6. Does the interface remain calm, scannable, and action-oriented?
+7. Is visual emphasis reserved for decisions and next actions?
+
+A feature that fails these questions should not displace the care-plan and emergency-readiness roadmap.
+
+## ChatGPT guidance
+
+When ChatGPT discusses PawPath features, UX, code, documentation, or roadmap choices, it should:
+
+- ground recommendations in the product distinction and current roadmap
+- use this guide as the visual and verbal brand source
+- recommend one clear direction rather than many equal options
+- explain how the direction supports travelers and urgent-use clarity
+- preserve the approved logo identity and palette
+- prefer open layout, selective cards, scan-friendly rows, and modest rounding
+- use color for emphasis rather than decoration
+- keep language calm, direct, transparent, and free of medical claims
+- treat accessibility, privacy, confidence language, and call-ahead guidance as brand requirements
+- avoid adding generic map features that do not produce a care-plan or action benefit
+
+## Review checklist
+
+Before approving a new screen, feature, document, or mockup:
+
+- Is the preparedness purpose immediately clear?
+- Is the next useful action obvious?
+- Are Primary and Backup roles understandable?
+- Is uncertainty labeled honestly?
+- Is the layout quieter than the content it supports?
+- Are cards used selectively?
+- Are lists easy to scan?
+- Is Amber reserved for meaningful action?
+- Is Danger used only when warranted?
+- Does the design work on a narrow mobile screen?
+- Does it avoid implying medical authority or guaranteed availability?

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,15 +6,18 @@ This directory contains the product definition and implementation guidance for e
 
 1. [Why PawPath?](WHY_PAWPATH.md)
 2. [Product Vision](PRODUCT_VISION.md)
-3. [Proof-of-Concept Scope](POC_SCOPE.md)
-4. [Roadmap](ROADMAP.md)
-5. [Phase 1 Backlog](BACKLOG.md)
-6. [Implementation Notes](IMPLEMENTATION_NOTES.md)
-7. [Demo Script](DEMO_SCRIPT.md)
+3. [Brand Guide](BRAND_GUIDE.md)
+4. [Proof-of-Concept Scope](POC_SCOPE.md)
+5. [Roadmap](ROADMAP.md)
+6. [Phase 1 Backlog](BACKLOG.md)
+7. [Implementation Notes](IMPLEMENTATION_NOTES.md)
+8. [Demo Script](DEMO_SCRIPT.md)
+
+The Brand Guide is the durable source for PawPath voice, visual identity, color use, UI shape strategy, accessibility expectations, and brand-aware feature decisions.
 
 ## ChatGPT Project package
 
-Use the [PawPath ChatGPT Project Setup](chatgpt-project/README.md) to create a dedicated long-running workspace with paste-ready project instructions, curated source files, current-state handoff, engineering workflow, and starter prompts.
+Use the [PawPath ChatGPT Project Setup](chatgpt-project/README.md) to create a dedicated long-running workspace with paste-ready project instructions, curated source files, current-state handoff, engineering workflow, brand guidance, and starter prompts.
 
 ## Current product objective
 

--- a/docs/chatgpt-project/CURRENT_STATE.md
+++ b/docs/chatgpt-project/CURRENT_STATE.md
@@ -79,6 +79,20 @@ Last updated: July 2026
 - Responsive desktop and mobile presentation
 - Cross-tab storage update handling
 
+### Approved brand system
+
+- Product category: **Pet-care preparedness for the road**
+- Brand promise: **Travel with a care plan**
+- Creative direction: **Trail guide, not alert siren**
+- Established PawPath mark and wordmark remain the approved identity
+- Muted Pine, Sage, Mist, Stone, Amber, Ink, and restrained Danger palette
+- Open layout for orientation and explanatory content
+- Selective light cards for saved plans, decisions, details, and urgent information
+- List-row treatment for scan-heavy facility results
+- Modest rounding, minimal shadows, and color reserved for meaningful emphasis
+- Durable guidance is documented in `docs/BRAND_GUIDE.md`
+- `brand-refresh.css` provides the focused visual alignment layer without changing application behavior
+
 ## Current Phase 1 roadmap status
 
 Completed:
@@ -106,6 +120,7 @@ Remaining after Emergency Mode:
 - Curated demo data: Issue #10
 - Printable emergency card: Issue #11
 - Shareable POC validation: Issue #12
+- Brand alignment: Issue #24
 
 ## Technical architecture
 
@@ -119,6 +134,7 @@ Current major files include:
 - `selection.css`
 - `care-plan.css`
 - `emergency-fallback.css`
+- `brand-refresh.css`
 - `plan-summary.css`
 - `leaflet-local.css`
 - `app.js`
@@ -141,6 +157,7 @@ Current major files include:
 - No user accounts, cloud sync, or multi-plan storage
 - Several modules wrap global functions; careless script-order changes can break behavior
 - Browser geolocation and remote API behavior require deployed or local-server testing
+- Brand-layer visual behavior still requires deployed desktop and mobile browser review
 
 ## Immediate implementation objective
 

--- a/docs/chatgpt-project/SOURCE_MANIFEST.md
+++ b/docs/chatgpt-project/SOURCE_MANIFEST.md
@@ -22,16 +22,33 @@ Add these first:
    - complete product positioning and competitive distinction
 5. `../PRODUCT_VISION.md`
    - mission, jobs to be done, principles, and product direction
-6. `../POC_SCOPE.md`
+6. `../BRAND_GUIDE.md`
+   - approved brand positioning, voice, palette, UI shape strategy, accessibility expectations, and feature-decision guardrails
+7. `../POC_SCOPE.md`
    - proof-of-concept requirements and release criteria
-7. `../ROADMAP.md`
+8. `../ROADMAP.md`
    - phased development plan
-8. `../IMPLEMENTATION_NOTES.md`
+9. `../IMPLEMENTATION_NOTES.md`
    - state, storage, data, confidence, and architecture guidance
-9. `../PHASE_1_RELEASE_PLAN.md`
+10. `../PHASE_1_RELEASE_PLAN.md`
    - increments and release gate
-10. `../../README.md`
+11. `../../README.md`
    - public repository overview and current capabilities
+
+## Brand use in ChatGPT
+
+For feature proposals, UX recommendations, mockups, documentation, and implementation planning, use `../BRAND_GUIDE.md` as the source for:
+
+- calm, practical, transparent voice
+- approved Pine / Sage / Mist / Stone / Amber / Ink / Danger palette
+- preservation of the established PawPath mark and wordmark
+- open layouts for orientation
+- selective cards for key decisions
+- list rows for scan-heavy results
+- modest rounding and minimal shadows
+- accessible, product-first emphasis
+
+Brand guidance does not override product safety, current `main` behavior, active issue acceptance criteria, or the immediate Phase 1 roadmap.
 
 ## Optional sources
 
@@ -61,8 +78,9 @@ After each significant merged increment:
 1. Update `CURRENT_STATE.md` in the repository.
 2. Update the README when public capabilities or the next task change.
 3. Replace the old uploaded `CURRENT_STATE.md` in the ChatGPT Project, or save the updated content as a new project source.
-4. Save important decision responses to the project sources when they establish lasting product direction.
-5. Avoid uploading every implementation chat; keep durable decisions and concise handoffs instead.
+4. Replace the uploaded `BRAND_GUIDE.md` when approved brand decisions change.
+5. Save important decision responses to the project sources when they establish lasting product direction.
+6. Avoid uploading every implementation chat; keep durable decisions and concise handoffs instead.
 
 ## Suggested project organization
 

--- a/emergency-fallback.css
+++ b/emergency-fallback.css
@@ -1,3 +1,5 @@
+@import url("brand-refresh.css");
+
 .expanded-emergency-search-notice {
   display: grid;
   gap: 3px;

--- a/plan-summary.css
+++ b/plan-summary.css
@@ -1,3 +1,5 @@
+@import url("brand-refresh.css");
+
 .saved-plan-summary {
   display: grid;
   gap: 18px;


### PR DESCRIPTION
## Summary

- adds a focused `brand-refresh.css` layer using the approved muted Pine, Sage, Mist, Stone, Amber, Ink, and restrained Danger palette
- softens the existing PawPath logo presentation while preserving the established mark and wordmark geometry
- changes the hero from a heavy dark treatment to a calmer product-first surface
- refines buttons, inputs, mode controls, selection surfaces, facility details, map framing, saved-plan presentation, and confidence states
- changes facility results from individually elevated cards to quieter scan-friendly rows with divider and selected-row emphasis
- adds `docs/BRAND_GUIDE.md` as the durable source for brand voice, visual identity, UI shape strategy, accessibility, and feature-decision guidance
- updates the documentation index, current-state handoff, and ChatGPT source manifest so future feature discussions use the approved brand system

## Why this strengthens PawPath

The refresh supports PawPath’s preparedness-first purpose without competing with the product task. It reserves visual emphasis for choosing, saving, calling, and navigating; preserves calm under pressure; and makes the interface feel more trustworthy and less color-led.

## Acceptance criteria addressed

- softened approved palette applied through shared tokens
- established logo identity preserved
- hero and controls made calmer
- facility results made easier to scan
- Primary, Backup, saved-plan, detail, and urgent states retain clear hierarchy
- brand guide added for product and ChatGPT use
- existing JavaScript, DOM IDs, storage schema, and script order remain unchanged

## Validation

- reviewed the complete branch diff against `main`
- confirmed the branch changes only CSS and documentation
- confirmed no JavaScript, storage, DOM-ID, or map initialization changes
- confirmed the brand layer is imported after the existing core, selection, and care-plan styles through `emergency-fallback.css`
- also imports the brand layer from `plan-summary.css` so the saved-plan module receives the same tokens when loaded
- retained visible focus styling and reduced-motion behavior from the existing application
- checked that all new CSS variables are defined in the brand layer before use

## Limitations / browser testing still required

- no automated browser-test suite exists
- deployed desktop, tablet, and narrow-mobile visual review is still required
- map sizing, Leaflet rendering, mode switching, facility selection, saved-plan restoration, and remote API behavior remain untested in a live browser in this change
- the existing logo files are preserved; the site applies a softened display treatment rather than replacing their geometry

Closes #24