### PR TITLE
Add branded PawPath documentation page

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -1,0 +1,677 @@
+:root {
+  --pine: #2f4b43;
+  --pine-deep: #273f39;
+  --pine-soft: #5f7f73;
+  --sage: #afc3b3;
+  --mist: #e8eee9;
+  --stone: #f3f1ec;
+  --canvas: #faf9f6;
+  --amber: #d8b58a;
+  --amber-deep: #9a673c;
+  --ink: #37424a;
+  --ink-soft: #566269;
+  --danger: #b85f50;
+  --border: #d8ded8;
+  --white: #ffffff;
+  --shadow: 0 18px 44px rgba(39, 63, 57, 0.1);
+  --content-width: 1160px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  background:
+    radial-gradient(circle at 88% 4%, rgba(216, 181, 138, 0.2), transparent 24rem),
+    linear-gradient(180deg, #fff 0, var(--canvas) 32rem, var(--stone) 100%);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  line-height: 1.65;
+}
+
+body.document-open {
+  background: var(--canvas);
+}
+
+a {
+  color: var(--pine-deep);
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.18em;
+}
+
+a:hover {
+  color: var(--amber-deep);
+}
+
+a:focus-visible,
+button:focus-visible {
+  outline: 3px solid rgba(216, 181, 138, 0.8);
+  outline-offset: 3px;
+}
+
+.skip-link {
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 1000;
+  transform: translateY(-180%);
+  border-radius: 10px;
+  padding: 10px 14px;
+  background: var(--white);
+  color: var(--pine-deep);
+  box-shadow: var(--shadow);
+  font-weight: 700;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.docs-shell {
+  width: min(100% - 32px, var(--content-width));
+  margin: 0 auto;
+  padding: 20px 0 48px;
+}
+
+.docs-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  border-bottom: 1px solid var(--border);
+  padding: 8px 2px 20px;
+}
+
+.brand-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 14px;
+  color: var(--pine-deep);
+  text-decoration: none;
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.brand-logo {
+  display: block;
+  width: min(250px, 48vw);
+  height: auto;
+}
+
+.docs-nav,
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.button {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  padding: 10px 16px;
+  text-decoration: none;
+  font-weight: 800;
+}
+
+.button-primary {
+  border-color: var(--pine-deep);
+  background: var(--pine);
+  color: var(--white);
+}
+
+.button-primary:hover {
+  background: var(--pine-deep);
+  color: var(--white);
+}
+
+.button-secondary {
+  border-color: var(--pine-soft);
+  background: var(--white);
+  color: var(--pine-deep);
+}
+
+.button-secondary:hover {
+  background: var(--mist);
+  color: var(--pine-deep);
+}
+
+.button-quiet {
+  border-color: var(--border);
+  background: transparent;
+  color: var(--pine-deep);
+}
+
+.button-quiet:hover {
+  background: var(--stone);
+  color: var(--pine-deep);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(280px, 0.72fr);
+  gap: clamp(28px, 5vw, 64px);
+  align-items: center;
+  margin-top: 28px;
+  border-radius: 24px;
+  padding: clamp(32px, 7vw, 76px);
+  background:
+    radial-gradient(circle at 92% 12%, rgba(216, 181, 138, 0.26), transparent 24rem),
+    linear-gradient(135deg, var(--pine-deep), var(--pine));
+  color: var(--white);
+  box-shadow: var(--shadow);
+}
+
+.eyebrow,
+.card-kicker {
+  margin: 0 0 8px;
+  color: var(--amber-deep);
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.hero .eyebrow,
+.hero-callout .eyebrow {
+  color: var(--amber);
+}
+
+.hero h1,
+.document-header h1 {
+  margin: 0;
+  color: inherit;
+  font-size: clamp(2.7rem, 7vw, 5.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.055em;
+}
+
+.hero-copy > p:not(.eyebrow) {
+  max-width: 720px;
+  margin: 22px 0 0;
+  color: rgba(255, 255, 255, 0.84);
+  font-size: clamp(1rem, 1.7vw, 1.18rem);
+}
+
+.hero-actions {
+  margin-top: 28px;
+}
+
+.hero .button-secondary {
+  border-color: rgba(255, 255, 255, 0.58);
+  background: transparent;
+  color: var(--white);
+}
+
+.hero .button-secondary:hover,
+.hero .button-quiet:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--white);
+}
+
+.hero .button-quiet {
+  border-color: transparent;
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.hero-callout {
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 18px;
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(12px);
+}
+
+.hero-callout strong {
+  display: block;
+  color: var(--white);
+  font-size: 1.3rem;
+  line-height: 1.2;
+}
+
+.hero-callout p:last-child {
+  margin-bottom: 0;
+  color: rgba(255, 255, 255, 0.76);
+  font-size: 0.92rem;
+}
+
+.path-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin: 22px 0 8px;
+}
+
+.path-step {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  min-height: 88px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 16px;
+  background: rgba(255, 255, 255, 0.84);
+}
+
+.path-number {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  place-items: center;
+  border-radius: 50%;
+  background: var(--mist);
+  color: var(--pine-deep);
+  font-weight: 900;
+}
+
+.path-step strong,
+.path-step small {
+  display: block;
+}
+
+.path-step strong {
+  color: var(--pine-deep);
+}
+
+.path-step small {
+  margin-top: 2px;
+  color: var(--ink-soft);
+}
+
+.docs-section {
+  padding-top: clamp(46px, 7vw, 76px);
+}
+
+.section-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.75fr);
+  gap: 30px;
+  align-items: end;
+  margin-bottom: 20px;
+}
+
+.section-heading h2,
+.source-note h2 {
+  margin: 0;
+  color: var(--pine-deep);
+  font-size: clamp(2rem, 4vw, 3.35rem);
+  line-height: 1;
+  letter-spacing: -0.045em;
+}
+
+.section-heading > p {
+  margin: 0;
+  color: var(--ink-soft);
+}
+
+.doc-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.doc-grid-two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.doc-card {
+  display: flex;
+  min-height: 290px;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 24px;
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.doc-card-featured {
+  border-color: rgba(95, 127, 115, 0.46);
+  background: linear-gradient(145deg, var(--mist), var(--white));
+}
+
+.doc-card h3 {
+  margin: 0;
+  color: var(--pine-deep);
+  font-size: 1.42rem;
+  line-height: 1.15;
+  letter-spacing: -0.025em;
+}
+
+.doc-card > p:not(.card-kicker) {
+  color: var(--ink-soft);
+}
+
+.card-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-top: auto;
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+  color: var(--pine-deep);
+  text-decoration: none;
+  font-weight: 800;
+}
+
+.card-link:hover {
+  color: var(--amber-deep);
+}
+
+.safety-note,
+.source-note,
+.noscript-note {
+  margin-top: 28px;
+  border-radius: 16px;
+  padding: 20px 22px;
+}
+
+.safety-note {
+  border-left: 5px solid var(--amber-deep);
+  background: #fff8ef;
+}
+
+.source-note {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(280px, 1.1fr);
+  gap: 28px;
+  align-items: center;
+  border: 1px solid var(--border);
+  background: var(--stone);
+}
+
+.source-note p:last-child {
+  margin: 0;
+}
+
+.source-note code {
+  border-radius: 6px;
+  padding: 2px 6px;
+  background: var(--white);
+  color: var(--pine-deep);
+}
+
+.document-view {
+  max-width: 920px;
+  margin: 0 auto;
+  padding-top: 30px;
+}
+
+.document-toolbar,
+.document-pager,
+.docs-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.document-toolbar {
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 18px;
+}
+
+.back-link,
+.source-link {
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.document-header {
+  margin: 46px 0 28px;
+  border-radius: 22px;
+  padding: clamp(28px, 6vw, 54px);
+  background: var(--pine-deep);
+  color: var(--white);
+}
+
+.document-header h1 {
+  max-width: 820px;
+  font-size: clamp(2.5rem, 6vw, 4.6rem);
+}
+
+.document-header > p:last-child {
+  max-width: 720px;
+  margin: 18px 0 0;
+  color: rgba(255, 255, 255, 0.76);
+}
+
+.document-status {
+  border-radius: 12px;
+  padding: 14px 16px;
+  background: var(--mist);
+  color: var(--pine-deep);
+}
+
+.document-status.is-error {
+  border-left: 4px solid var(--danger);
+  background: #fff2ef;
+  color: #7a3028;
+}
+
+.markdown-body {
+  font-size: 1rem;
+}
+
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body h3,
+.markdown-body h4 {
+  color: var(--pine-deep);
+  line-height: 1.15;
+  scroll-margin-top: 24px;
+}
+
+.markdown-body h2 {
+  margin: 2.6em 0 0.7em;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 0.35em;
+  font-size: clamp(1.7rem, 4vw, 2.35rem);
+  letter-spacing: -0.035em;
+}
+
+.markdown-body h3 {
+  margin-top: 2em;
+  font-size: 1.3rem;
+}
+
+.markdown-body p,
+.markdown-body li {
+  max-width: 78ch;
+}
+
+.markdown-body blockquote {
+  margin: 1.5em 0;
+  border-left: 4px solid var(--amber);
+  border-radius: 0 12px 12px 0;
+  padding: 0.8em 1.1em;
+  background: #fff8ef;
+  color: var(--pine-deep);
+}
+
+.markdown-body blockquote > :first-child {
+  margin-top: 0;
+}
+
+.markdown-body blockquote > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body table {
+  display: block;
+  width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+  margin: 1.5em 0;
+}
+
+.markdown-body th,
+.markdown-body td {
+  min-width: 180px;
+  border: 1px solid var(--border);
+  padding: 10px 12px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.markdown-body th {
+  background: var(--mist);
+  color: var(--pine-deep);
+}
+
+.markdown-body pre {
+  overflow-x: auto;
+  border-radius: 14px;
+  padding: 18px;
+  background: var(--pine-deep);
+  color: #f7faf8;
+}
+
+.markdown-body :not(pre) > code {
+  border-radius: 5px;
+  padding: 2px 5px;
+  background: var(--mist);
+  color: var(--pine-deep);
+}
+
+.markdown-body hr {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 2.5em 0;
+}
+
+.markdown-body img {
+  max-width: 100%;
+  height: auto;
+}
+
+.document-pager {
+  margin-top: 54px;
+  border-top: 1px solid var(--border);
+  padding-top: 20px;
+}
+
+.document-pager a {
+  max-width: 46%;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.docs-footer {
+  margin-top: 64px;
+  border-top: 1px solid var(--border);
+  padding-top: 22px;
+  color: var(--ink-soft);
+  font-size: 0.88rem;
+}
+
+.noscript-note {
+  border-left: 4px solid var(--danger);
+  background: #fff2ef;
+}
+
+[hidden] {
+  display: none !important;
+}
+
+@media (max-width: 860px) {
+  .section-heading,
+  .source-note {
+    grid-template-columns: 1fr;
+  }
+
+  .docs-header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .doc-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .docs-shell {
+    width: min(100% - 24px, var(--content-width));
+    padding-top: 12px;
+  }
+
+  .brand-link {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .brand-logo {
+    width: min(238px, 78vw);
+  }
+
+  .docs-nav,
+  .hero-actions {
+    width: 100%;
+  }
+
+  .docs-nav .button,
+  .hero-actions .button {
+    width: 100%;
+  }
+
+  .hero {
+    border-radius: 18px;
+    padding: 30px 22px;
+  }
+
+  .path-strip,
+  .doc-grid,
+  .doc-grid-two {
+    grid-template-columns: 1fr;
+  }
+
+  .doc-card {
+    min-height: 250px;
+  }
+
+  .section-heading {
+    gap: 12px;
+  }
+
+  .document-header {
+    margin-top: 28px;
+    padding: 30px 22px;
+  }
+
+  .document-toolbar,
+  .document-pager,
+  .docs-footer {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .document-pager a {
+    max-width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}

--- a/docs/docs.js
+++ b/docs/docs.js
@@ -159,9 +159,7 @@
       markdownContent.innerHTML = window.DOMPurify.sanitize(rendered, { USE_PROFILES: { html: true } });
 
       const firstHeading = markdownContent.querySelector("h1");
-      if (firstHeading && firstHeading.textContent.trim().toLowerCase() === doc.title.toLowerCase()) {
-        firstHeading.remove();
-      }
+      firstHeading?.remove();
 
       makeRenderedLinksSafe();
       documentStatus.hidden = true;

--- a/docs/docs.js
+++ b/docs/docs.js
@@ -1,0 +1,211 @@
+(() => {
+  "use strict";
+
+  const repositoryDocsUrl = "https://github.com/jeffthomasiii/pawpath/blob/main/docs/";
+  const documents = [
+    {
+      slug: "why-pawpath",
+      file: "WHY_PAWPATH.md",
+      title: "Why PawPath?",
+      eyebrow: "Product distinction",
+      description: "The problem PawPath solves, who it serves, and why the outcome must be a care plan rather than a list of places."
+    },
+    {
+      slug: "product-vision",
+      file: "PRODUCT_VISION.md",
+      title: "Product Vision",
+      eyebrow: "Direction",
+      description: "Mission, jobs to be done, core experiences, trust principles, success criteria, and long-term opportunity."
+    },
+    {
+      slug: "brand-guide",
+      file: "BRAND_GUIDE.md",
+      title: "Brand Guide",
+      eyebrow: "Brand source",
+      description: "The durable voice, visual, interaction, accessibility, and product-decision guidance for PawPath."
+    },
+    {
+      slug: "poc-scope",
+      file: "POC_SCOPE.md",
+      title: "Proof-of-Concept Scope",
+      eyebrow: "Requirements",
+      description: "The complete v0.2 demonstration outcome, required capabilities, acceptance criteria, and explicit non-goals."
+    },
+    {
+      slug: "roadmap",
+      file: "ROADMAP.md",
+      title: "Roadmap",
+      eyebrow: "Product phases",
+      description: "The phased path from a care-plan proof of concept to stronger trust, route planning, offline readiness, and a broader platform."
+    },
+    {
+      slug: "backlog",
+      file: "BACKLOG.md",
+      title: "Phase 1 Backlog",
+      eyebrow: "Work packages",
+      description: "The implementation sequence and release gate for POC-01 through POC-09."
+    },
+    {
+      slug: "implementation-notes",
+      file: "IMPLEMENTATION_NOTES.md",
+      title: "Implementation Notes",
+      eyebrow: "Technical guidance",
+      description: "Practical architecture, state, storage, data-confidence, accessibility, and definition-of-done guidance for the static application."
+    },
+    {
+      slug: "demo-script",
+      file: "DEMO_SCRIPT.md",
+      title: "Demo Script",
+      eyebrow: "Product story",
+      description: "A focused walkthrough and feedback guide for proving that viewers understand the PawPath distinction."
+    }
+  ];
+
+  const home = document.querySelector("#docs-home");
+  const documentView = document.querySelector("#document-view");
+  const documentTitle = document.querySelector("#document-title");
+  const documentEyebrow = document.querySelector("#document-eyebrow");
+  const documentDescription = document.querySelector("#document-description");
+  const documentStatus = document.querySelector("#document-status");
+  const markdownContent = document.querySelector("#markdown-content");
+  const sourceLink = document.querySelector("#document-source-link");
+  const previousLink = document.querySelector("#previous-document");
+  const nextLink = document.querySelector("#next-document");
+  const homeLinks = document.querySelectorAll("[data-home-link]");
+  let renderRequest = 0;
+
+  const findDocumentByHash = () => {
+    const slug = window.location.hash.replace(/^#/, "").trim();
+    return documents.find((document) => document.slug === slug) || null;
+  };
+
+  const setHomeView = () => {
+    renderRequest += 1;
+    home.hidden = false;
+    documentView.hidden = true;
+    document.body.classList.remove("document-open");
+    document.title = "PawPath Documentation";
+  };
+
+  const configurePager = (doc) => {
+    const index = documents.findIndex((item) => item.slug === doc.slug);
+    const previous = documents[index - 1] || null;
+    const next = documents[index + 1] || null;
+
+    previousLink.hidden = !previous;
+    nextLink.hidden = !next;
+
+    if (previous) {
+      previousLink.href = `#${previous.slug}`;
+      previousLink.textContent = `← ${previous.title}`;
+    }
+
+    if (next) {
+      nextLink.href = `#${next.slug}`;
+      nextLink.textContent = `${next.title} →`;
+    }
+  };
+
+  const makeRenderedLinksSafe = () => {
+    markdownContent.querySelectorAll("a[href]").forEach((link) => {
+      const href = link.getAttribute("href") || "";
+      const matchingDocument = documents.find((document) => href.endsWith(document.file));
+
+      if (matchingDocument) {
+        link.setAttribute("href", `#${matchingDocument.slug}`);
+        return;
+      }
+
+      if (/^https?:\/\//i.test(href)) {
+        link.setAttribute("target", "_blank");
+        link.setAttribute("rel", "noopener noreferrer");
+      }
+    });
+  };
+
+  const renderDocument = async (doc) => {
+    const requestId = ++renderRequest;
+    home.hidden = true;
+    documentView.hidden = false;
+    document.body.classList.add("document-open");
+
+    documentTitle.textContent = doc.title;
+    documentEyebrow.textContent = doc.eyebrow;
+    documentDescription.textContent = doc.description;
+    sourceLink.href = `${repositoryDocsUrl}${doc.file}`;
+    documentStatus.hidden = false;
+    documentStatus.classList.remove("is-error");
+    documentStatus.textContent = "Loading document…";
+    markdownContent.replaceChildren();
+    configurePager(doc);
+    window.document.title = `${doc.title} | PawPath Documentation`;
+
+    window.scrollTo({ top: 0, behavior: "auto" });
+
+    try {
+      if (!window.marked || !window.DOMPurify) {
+        throw new Error("The document renderer did not load.");
+      }
+
+      const response = await fetch(doc.file, { cache: "no-cache" });
+      if (!response.ok) {
+        throw new Error(`Document request failed with status ${response.status}.`);
+      }
+
+      const markdown = await response.text();
+      if (requestId !== renderRequest) return;
+
+      const rendered = window.marked.parse(markdown, { gfm: true });
+      markdownContent.innerHTML = window.DOMPurify.sanitize(rendered, { USE_PROFILES: { html: true } });
+
+      const firstHeading = markdownContent.querySelector("h1");
+      if (firstHeading && firstHeading.textContent.trim().toLowerCase() === doc.title.toLowerCase()) {
+        firstHeading.remove();
+      }
+
+      makeRenderedLinksSafe();
+      documentStatus.hidden = true;
+      documentTitle.focus?.();
+    } catch (error) {
+      if (requestId !== renderRequest) return;
+      documentStatus.hidden = false;
+      documentStatus.classList.add("is-error");
+      const message = document.createTextNode("The document could not be displayed here. ");
+      const fallbackLink = document.createElement("a");
+      fallbackLink.href = `${repositoryDocsUrl}${doc.file}`;
+      fallbackLink.target = "_blank";
+      fallbackLink.rel = "noopener noreferrer";
+      fallbackLink.textContent = "Open the Markdown source on GitHub";
+      documentStatus.replaceChildren(message, fallbackLink, document.createTextNode("."));
+      console.error("PawPath documentation render failed:", error);
+    }
+  };
+
+  const route = () => {
+    const hash = window.location.hash.replace(/^#/, "").trim();
+    if (!hash || hash === "home") {
+      setHomeView();
+      return;
+    }
+
+    const doc = findDocumentByHash();
+    if (!doc) {
+      window.location.hash = "home";
+      return;
+    }
+
+    renderDocument(doc);
+  };
+
+  homeLinks.forEach((link) => {
+    link.addEventListener("click", () => {
+      if (window.location.hash === "#home") {
+        setHomeView();
+        window.scrollTo({ top: 0, behavior: "auto" });
+      }
+    });
+  });
+
+  window.addEventListener("hashchange", route);
+  route();
+})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,207 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="PawPath product documentation, brand guidance, proof-of-concept scope, roadmap, implementation notes, and demo resources."
+    />
+    <meta name="theme-color" content="#2f4b43" />
+    <title>PawPath Documentation</title>
+    <link rel="icon" href="../assets/PawPath_mark_transparent.png" type="image/png" />
+    <link rel="stylesheet" href="docs.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+
+    <main id="main-content" class="docs-shell">
+      <header class="docs-header">
+        <a class="brand-link" href="../" aria-label="Back to the PawPath app">
+          <img class="brand-logo" src="../assets/PawPath_logo_Transparent.png" alt="PawPath" />
+          <span>Product documentation</span>
+        </a>
+        <nav class="docs-nav" aria-label="Documentation navigation">
+          <a class="button button-secondary" href="#home" data-home-link>Documentation home</a>
+          <a class="button button-primary" href="../">Back to app</a>
+        </nav>
+      </header>
+
+      <section id="docs-home" aria-labelledby="docs-title">
+        <section class="hero">
+          <div class="hero-copy">
+            <p class="eyebrow">PawPath documentation</p>
+            <h1 id="docs-title">Travel with a care plan.</h1>
+            <p>
+              Product strategy, brand guidance, proof-of-concept requirements, roadmap, and implementation notes for
+              a calmer pet-care preparedness experience on the road.
+            </p>
+            <div class="hero-actions">
+              <a class="button button-primary" href="#why-pawpath">Start with why PawPath</a>
+              <a class="button button-secondary" href="#poc-scope">Review the POC scope</a>
+              <a class="button button-quiet" href="../">Open PawPath</a>
+            </div>
+          </div>
+          <aside class="hero-callout" aria-label="Current product objective">
+            <p class="eyebrow">Current objective</p>
+            <strong>v0.2 — Care Plan POC</strong>
+            <p>
+              Make it clear within two minutes that PawPath is a destination-based care-planning and emergency-readiness
+              workflow, not merely a veterinarian map.
+            </p>
+          </aside>
+        </section>
+
+        <section class="path-strip" aria-label="PawPath product workflow">
+          <article class="path-step">
+            <span class="path-number" aria-hidden="true">1</span>
+            <span><strong>Prepare</strong><small>Search the destination before the trip.</small></span>
+          </article>
+          <article class="path-step">
+            <span class="path-number" aria-hidden="true">2</span>
+            <span><strong>Choose</strong><small>Save a Primary and distinct Backup.</small></span>
+          </article>
+          <article class="path-step">
+            <span class="path-number" aria-hidden="true">3</span>
+            <span><strong>Act</strong><small>Call and start directions with fewer decisions.</small></span>
+          </article>
+        </section>
+
+        <section class="docs-section" aria-labelledby="foundation-title">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">Start here</p>
+              <h2 id="foundation-title">Product foundation</h2>
+            </div>
+            <p>Understand the problem, promise, audience, product principles, and approved brand direction.</p>
+          </div>
+          <div class="doc-grid">
+            <article class="doc-card doc-card-featured">
+              <p class="card-kicker">Product distinction</p>
+              <h3>Why PawPath?</h3>
+              <p>Why general maps are not enough, who PawPath serves, and the care-plan workflow that defines the product.</p>
+              <a class="card-link" href="#why-pawpath">Read why PawPath <span aria-hidden="true">→</span></a>
+            </article>
+            <article class="doc-card">
+              <p class="card-kicker">Direction</p>
+              <h3>Product Vision</h3>
+              <p>Mission, jobs to be done, core experiences, trust model, principles, and proof-of-concept success criteria.</p>
+              <a class="card-link" href="#product-vision">Read the vision <span aria-hidden="true">→</span></a>
+            </article>
+            <article class="doc-card">
+              <p class="card-kicker">Brand source</p>
+              <h3>Brand Guide</h3>
+              <p>Voice, visual system, color use, interface shape strategy, accessibility, and the “trail guide” direction.</p>
+              <a class="card-link" href="#brand-guide">Read the brand guide <span aria-hidden="true">→</span></a>
+            </article>
+          </div>
+        </section>
+
+        <section class="docs-section" aria-labelledby="poc-title">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">Build the shareable proof of concept</p>
+              <h2 id="poc-title">Scope and sequence</h2>
+            </div>
+            <p>Use these documents to define what belongs in v0.2, how it is ordered, and when the release is ready to share.</p>
+          </div>
+          <div class="doc-grid">
+            <article class="doc-card">
+              <p class="card-kicker">Requirements</p>
+              <h3>Proof-of-Concept Scope</h3>
+              <p>The complete demonstration outcome, required capabilities, data strategy, acceptance criteria, and non-goals.</p>
+              <a class="card-link" href="#poc-scope">Review the POC scope <span aria-hidden="true">→</span></a>
+            </article>
+            <article class="doc-card">
+              <p class="card-kicker">Work packages</p>
+              <h3>Phase 1 Backlog</h3>
+              <p>POC-01 through POC-09, arranged around product structure, care planning, emergency use, and validation.</p>
+              <a class="card-link" href="#backlog">Open the backlog <span aria-hidden="true">→</span></a>
+            </article>
+            <article class="doc-card">
+              <p class="card-kicker">Product phases</p>
+              <h3>Roadmap</h3>
+              <p>The path from the Care Plan POC to trust, route planning, offline readiness, pet profiles, and a broader platform.</p>
+              <a class="card-link" href="#roadmap">View the roadmap <span aria-hidden="true">→</span></a>
+            </article>
+          </div>
+        </section>
+
+        <section class="docs-section" aria-labelledby="delivery-title">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">Deliver and demonstrate</p>
+              <h2 id="delivery-title">Implementation resources</h2>
+            </div>
+            <p>Translate product decisions into the static application and demonstrate the value without overstating its capabilities.</p>
+          </div>
+          <div class="doc-grid doc-grid-two">
+            <article class="doc-card">
+              <p class="card-kicker">Technical guidance</p>
+              <h3>Implementation Notes</h3>
+              <p>Data objects, state, local storage, confidence language, file evolution, accessibility, and the definition of done.</p>
+              <a class="card-link" href="#implementation-notes">Read implementation notes <span aria-hidden="true">→</span></a>
+            </article>
+            <article class="doc-card">
+              <p class="card-kicker">Product story</p>
+              <h3>Demo Script</h3>
+              <p>A two-to-three-minute walkthrough, a thirty-second version, viewer questions, and the validation signal that matters.</p>
+              <a class="card-link" href="#demo-script">Open the demo script <span aria-hidden="true">→</span></a>
+            </article>
+          </div>
+        </section>
+
+        <section class="safety-note" aria-label="PawPath safety boundary">
+          <strong>Planning support, not veterinary advice:</strong>
+          PawPath does not diagnose, medically triage, or guarantee that a facility is open, available, or appropriate for a
+          specific pet or condition. Call ahead and confirm services, hours, species accepted, and availability.
+        </section>
+
+        <section class="source-note" aria-label="Documentation source note">
+          <div>
+            <p class="eyebrow">Markdown remains the source of truth</p>
+            <h2>One documentation system, no duplicate editing.</h2>
+          </div>
+          <p>
+            This page renders the Markdown files already maintained in <code>PawPath/docs</code>. Update those files and the
+            documentation view updates with them.
+          </p>
+        </section>
+      </section>
+
+      <section id="document-view" class="document-view" aria-labelledby="document-title" hidden>
+        <div class="document-toolbar">
+          <a class="back-link" href="#home"><span aria-hidden="true">←</span> Documentation home</a>
+          <a id="document-source-link" class="source-link" href="#" target="_blank" rel="noopener noreferrer">View Markdown on GitHub <span aria-hidden="true">↗</span></a>
+        </div>
+        <header class="document-header">
+          <p id="document-eyebrow" class="eyebrow">PawPath documentation</p>
+          <h1 id="document-title" tabindex="-1">Document</h1>
+          <p id="document-description"></p>
+        </header>
+        <p id="document-status" class="document-status" role="status" aria-live="polite">Loading document…</p>
+        <article id="markdown-content" class="markdown-body"></article>
+        <nav class="document-pager" aria-label="Document navigation">
+          <a id="previous-document" href="#"></a>
+          <a id="next-document" href="#"></a>
+        </nav>
+      </section>
+
+      <noscript>
+        <section class="noscript-note">
+          JavaScript is needed to render the Markdown documents inside this page. The source files remain available in the
+          <a href="https://github.com/jeffthomasiii/pawpath/tree/main/docs">PawPath docs directory on GitHub</a>.
+        </section>
+      </noscript>
+
+      <footer class="docs-footer">
+        <span>PawPath product documentation</span>
+        <span><a href="#home" data-home-link>Documentation home</a> · <a href="../">Back to app</a></span>
+      </footer>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js" defer></script>
+    <script src="docs.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## What changed

- Added a PawPath-branded documentation landing page at `/docs/`
- Organized the eight durable product documents listed in `docs/README.md` into Product foundation, Scope and sequence, and Implementation resources
- Added a hash-routed document reader that fetches the existing Markdown files so they remain the source of truth
- Sanitized rendered Markdown with DOMPurify and provided direct GitHub source fallbacks
- Added responsive desktop and mobile layouts, visible focus states, reduced-motion handling, document paging, and a no-JavaScript source fallback
- Included the PawPath product workflow, current v0.2 objective, and call-ahead safety boundary

## Why this strengthens PawPath

The page makes the product distinction and care-plan workflow visible before a reader opens an individual source document. It applies the approved “trail guide, not alert siren” direction while keeping the documentation lightweight, understandable, and compatible with the existing static GitHub Pages architecture.

## Validation performed

- Confirmed `docs/index.html` did not already exist on `main`
- Parsed the new HTML and checked for duplicate IDs
- Ran `node --check` against `docs/docs.js`
- Reviewed relative logo, stylesheet, script, Markdown, app, and GitHub source paths
- Reviewed responsive breakpoints, focus states, reduced-motion handling, and the sanitized Markdown insertion path
- Confirmed the change is isolated to three new files under `docs/`

## Limitations and follow-up testing

- Live GitHub Pages rendering still needs deployed desktop and mobile browser review
- The Markdown reader depends on pinned jsDelivr copies of Marked and DOMPurify; when those scripts are unavailable, the page displays a direct GitHub source fallback
- No automated browser-test suite exists in the repository

Closes #26