### PR TITLE
Link the app to PawPath documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="selection.css" />
     <link rel="stylesheet" href="care-plan.css" />
     <link rel="stylesheet" href="emergency-fallback.css" />
+    <link rel="stylesheet" href="site-navigation.css" />
   </head>
 
   <body>
@@ -29,7 +30,10 @@
         <img class="brand-logo" src="assets/PawPath_logo_Transparent.png" alt="PawPath" />
         <span class="brand-tagline">Pet-care preparedness for the road</span>
       </a>
-      <span class="status-badge">Free map access</span>
+      <div class="site-header-actions" aria-label="Site navigation">
+        <a class="header-link" href="docs/">Documentation</a>
+        <span class="status-badge">Free map access</span>
+      </div>
     </header>
 
     <main id="main-content" class="app-shell">

--- a/site-navigation.css
+++ b/site-navigation.css
@@ -1,0 +1,56 @@
+/* Header utility navigation for the application and documentation. */
+
+.site-header-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.header-link {
+  display: inline-flex;
+  min-height: 40px;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 13px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--white);
+  color: var(--forest-900);
+  box-shadow: none;
+  font-size: 0.82rem;
+  font-weight: 750;
+  text-decoration: none;
+  transition: background 160ms ease, border-color 160ms ease;
+}
+
+.header-link:hover {
+  border-color: var(--forest-700);
+  background: var(--sage-50);
+}
+
+.header-link:focus-visible {
+  outline: 3px solid rgba(95, 127, 115, 0.46);
+  outline-offset: 3px;
+}
+
+@media (max-width: 780px) {
+  .site-header-actions {
+    gap: 8px;
+  }
+}
+
+@media (max-width: 460px) {
+  .header-link {
+    min-height: 38px;
+    padding: 7px 10px;
+    font-size: 0.78rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .header-link {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## What changed

- Added a visible **Documentation** link to the PawPath application header
- Linked the entry point to the new static `/docs/` experience
- Grouped the link with the existing Free map access status badge
- Added a focused `site-navigation.css` module with hover, keyboard-focus, narrow-mobile, and reduced-motion behavior

## Why this strengthens PawPath

The product documentation is now discoverable from the application itself instead of requiring a direct URL. The link remains secondary to Plan a Trip and Find Care Now, so it improves product orientation without competing with the care-planning workflow.

## Validation performed

- Confirmed the branch is based on the current `main` commit and is not behind
- Confirmed the diff is limited to `index.html` and the new `site-navigation.css`
- Parsed the updated HTML and checked for duplicate IDs
- Confirmed `docs/` is the correct relative GitHub Pages route
- Confirmed the committed HTML and CSS blob hashes match the locally validated files
- Reviewed the existing mobile breakpoints: the Documentation link remains visible while the status badge keeps its current mobile collapse behavior
- Confirmed no JavaScript, map, search, facility, or local-storage files changed

## Remaining browser validation

- Review the deployed header on desktop and at a 320px viewport width
- Confirm keyboard focus appearance in a browser
- Confirm GitHub Pages navigation reaches `/pawpath/docs/`

Closes #28