### PR TITLE
Refine public PawPath documentation

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -1,20 +1,27 @@
 :root {
-  --pine: #2f4b43;
-  --pine-deep: #273f39;
-  --pine-soft: #5f7f73;
-  --sage: #afc3b3;
-  --mist: #e8eee9;
-  --stone: #f3f1ec;
-  --canvas: #faf9f6;
-  --amber: #d8b58a;
-  --amber-deep: #9a673c;
-  --ink: #37424a;
-  --ink-soft: #566269;
+  --forest-950: #273f39;
+  --forest-900: #2f4b43;
+  --forest-800: #3f6258;
+  --forest-700: #5f7f73;
+  --sage-100: #dce6df;
+  --sage-50: #eef3ef;
+  --sand-50: #faf9f6;
+  --sand-100: #f3f1ec;
+  --amber-500: #d8b58a;
+  --amber-600: #cda779;
+  --ink-900: #37424a;
+  --ink-700: #566269;
+  --ink-500: #737d81;
   --danger: #b85f50;
   --border: #d8ded8;
   --white: #ffffff;
-  --shadow: 0 18px 44px rgba(39, 63, 57, 0.1);
-  --content-width: 1160px;
+  --shadow-sm: 0 6px 18px rgba(47, 75, 67, 0.06);
+  --shadow-md: 0 14px 34px rgba(47, 75, 67, 0.1);
+  --radius-sm: 10px;
+  --radius-md: 16px;
+  --radius-lg: 24px;
+  --content-width: 1440px;
+  --reading-width: 920px;
 }
 
 * {
@@ -28,31 +35,29 @@ html {
 body {
   margin: 0;
   min-width: 320px;
-  background:
-    radial-gradient(circle at 88% 4%, rgba(216, 181, 138, 0.2), transparent 24rem),
-    linear-gradient(180deg, #fff 0, var(--canvas) 32rem, var(--stone) 100%);
-  color: var(--ink);
+  background: var(--sand-50);
+  color: var(--ink-900);
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  line-height: 1.65;
+  line-height: 1.6;
 }
 
 body.document-open {
-  background: var(--canvas);
+  background: var(--sand-50);
 }
 
 a {
-  color: var(--pine-deep);
+  color: var(--forest-900);
   text-decoration-thickness: 0.08em;
   text-underline-offset: 0.18em;
 }
 
 a:hover {
-  color: var(--amber-deep);
+  color: var(--forest-700);
 }
 
 a:focus-visible,
 button:focus-visible {
-  outline: 3px solid rgba(216, 181, 138, 0.8);
+  outline: 3px solid rgba(95, 127, 115, 0.46);
   outline-offset: 3px;
 }
 
@@ -62,56 +67,168 @@ button:focus-visible {
   left: 12px;
   z-index: 1000;
   transform: translateY(-180%);
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
   padding: 10px 14px;
   background: var(--white);
-  color: var(--pine-deep);
-  box-shadow: var(--shadow);
-  font-weight: 700;
+  color: var(--forest-900);
+  box-shadow: var(--shadow-sm);
+  font-weight: 750;
 }
 
 .skip-link:focus {
   transform: translateY(0);
 }
 
+.site-header,
 .docs-shell {
   width: min(100% - 32px, var(--content-width));
   margin: 0 auto;
-  padding: 20px 0 48px;
 }
 
-.docs-header {
+.site-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 24px;
-  border-bottom: 1px solid var(--border);
-  padding: 8px 2px 20px;
+  padding: 22px 0 18px;
 }
 
-.brand-link {
+.brand {
   display: inline-flex;
   align-items: center;
   gap: 14px;
-  color: var(--pine-deep);
+  color: inherit;
   text-decoration: none;
-  font-size: 0.82rem;
-  font-weight: 800;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
 }
 
 .brand-logo {
   display: block;
-  width: min(250px, 48vw);
+  width: clamp(184px, 17vw, 238px);
   height: auto;
+  filter: saturate(0.72) brightness(1.08);
 }
 
-.docs-nav,
-.hero-actions {
+.brand-tagline {
+  max-width: 170px;
+  color: var(--ink-700);
+  font-size: 0.76rem;
+  font-weight: 650;
+  line-height: 1.25;
+}
+
+.site-header-actions,
+.hero-actions,
+.document-toolbar,
+.document-pager,
+.docs-footer {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 10px;
+}
+
+.site-header-actions {
+  justify-content: flex-end;
+}
+
+.header-link {
+  display: inline-flex;
+  min-height: 40px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 13px;
+  background: rgba(255, 255, 255, 0.78);
+  color: var(--forest-900);
+  font-size: 0.82rem;
+  font-weight: 750;
+  text-decoration: none;
+}
+
+.header-link:hover {
+  border-color: var(--forest-700);
+  background: var(--white);
+  color: var(--forest-900);
+}
+
+.header-link-primary {
+  border-color: var(--amber-600);
+  background: var(--amber-500);
+  color: #27352f;
+}
+
+.header-link-primary:hover {
+  background: #cfaa7d;
+  color: #27352f;
+}
+
+.docs-shell {
+  padding-bottom: 48px;
+}
+
+.hero-panel {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(280px, 0.7fr);
+  align-items: center;
+  gap: clamp(28px, 5vw, 60px);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: clamp(32px, 6vw, 68px);
+  background:
+    radial-gradient(circle at 88% 12%, rgba(216, 181, 138, 0.22), transparent 30%),
+    linear-gradient(135deg, var(--sage-50) 0%, #f7f5f0 62%, var(--sand-100) 100%);
+  color: var(--ink-900);
+  box-shadow: var(--shadow-sm);
+}
+
+.hero-panel::after {
+  content: "";
+  position: absolute;
+  right: -90px;
+  bottom: -120px;
+  width: 300px;
+  height: 300px;
+  border: 1px solid rgba(47, 75, 67, 0.08);
+  border-radius: 50%;
+}
+
+.hero-copy,
+.hero-callout {
+  position: relative;
+  z-index: 1;
+}
+
+.eyebrow,
+.card-kicker {
+  margin: 0 0 8px;
+  color: var(--forest-700);
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.hero-panel h1,
+.document-header h1 {
+  margin: 0;
+  color: var(--forest-950);
+  font-size: clamp(2.55rem, 6vw, 4.8rem);
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+}
+
+.hero-copy > p:not(.eyebrow) {
+  max-width: 710px;
+  margin: 20px 0 0;
+  color: var(--ink-700);
+  font-size: clamp(1rem, 1.5vw, 1.14rem);
+}
+
+.hero-actions {
+  margin-top: 26px;
 }
 
 .button {
@@ -120,130 +237,62 @@ button:focus-visible {
   align-items: center;
   justify-content: center;
   border: 1px solid transparent;
-  border-radius: 10px;
+  border-radius: var(--radius-sm);
   padding: 10px 16px;
+  font: inherit;
+  font-weight: 750;
   text-decoration: none;
-  font-weight: 800;
+  transition: background 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
 }
 
 .button-primary {
-  border-color: var(--pine-deep);
-  background: var(--pine);
-  color: var(--white);
+  border-color: var(--amber-600);
+  background: var(--amber-500);
+  color: #27352f;
 }
 
 .button-primary:hover {
-  background: var(--pine-deep);
-  color: var(--white);
+  background: #cfaa7d;
+  color: #27352f;
+  box-shadow: 0 5px 14px rgba(47, 75, 67, 0.08);
 }
 
-.button-secondary {
-  border-color: var(--pine-soft);
+.button-secondary,
+.button-quiet {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.78);
+  color: var(--forest-900);
+}
+
+.button-secondary:hover,
+.button-quiet:hover {
   background: var(--white);
-  color: var(--pine-deep);
-}
-
-.button-secondary:hover {
-  background: var(--mist);
-  color: var(--pine-deep);
+  color: var(--forest-900);
 }
 
 .button-quiet {
-  border-color: var(--border);
   background: transparent;
-  color: var(--pine-deep);
-}
-
-.button-quiet:hover {
-  background: var(--stone);
-  color: var(--pine-deep);
-}
-
-.hero {
-  display: grid;
-  grid-template-columns: minmax(0, 1.5fr) minmax(280px, 0.72fr);
-  gap: clamp(28px, 5vw, 64px);
-  align-items: center;
-  margin-top: 28px;
-  border-radius: 24px;
-  padding: clamp(32px, 7vw, 76px);
-  background:
-    radial-gradient(circle at 92% 12%, rgba(216, 181, 138, 0.26), transparent 24rem),
-    linear-gradient(135deg, var(--pine-deep), var(--pine));
-  color: var(--white);
-  box-shadow: var(--shadow);
-}
-
-.eyebrow,
-.card-kicker {
-  margin: 0 0 8px;
-  color: var(--amber-deep);
-  font-size: 0.74rem;
-  font-weight: 800;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
-.hero .eyebrow,
-.hero-callout .eyebrow {
-  color: var(--amber);
-}
-
-.hero h1,
-.document-header h1 {
-  margin: 0;
-  color: inherit;
-  font-size: clamp(2.7rem, 7vw, 5.5rem);
-  line-height: 0.95;
-  letter-spacing: -0.055em;
-}
-
-.hero-copy > p:not(.eyebrow) {
-  max-width: 720px;
-  margin: 22px 0 0;
-  color: rgba(255, 255, 255, 0.84);
-  font-size: clamp(1rem, 1.7vw, 1.18rem);
-}
-
-.hero-actions {
-  margin-top: 28px;
-}
-
-.hero .button-secondary {
-  border-color: rgba(255, 255, 255, 0.58);
-  background: transparent;
-  color: var(--white);
-}
-
-.hero .button-secondary:hover,
-.hero .button-quiet:hover {
-  background: rgba(255, 255, 255, 0.12);
-  color: var(--white);
-}
-
-.hero .button-quiet {
-  border-color: transparent;
-  color: rgba(255, 255, 255, 0.88);
 }
 
 .hero-callout {
-  border: 1px solid rgba(255, 255, 255, 0.22);
-  border-radius: 18px;
+  border: 1px solid rgba(47, 75, 67, 0.12);
+  border-radius: var(--radius-md);
   padding: 24px;
-  background: rgba(255, 255, 255, 0.08);
-  backdrop-filter: blur(12px);
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 8px 24px rgba(47, 75, 67, 0.06);
+  backdrop-filter: blur(10px);
 }
 
 .hero-callout strong {
   display: block;
-  color: var(--white);
-  font-size: 1.3rem;
-  line-height: 1.2;
+  color: var(--forest-950);
+  font-size: 1.28rem;
+  line-height: 1.22;
 }
 
 .hero-callout p:last-child {
   margin-bottom: 0;
-  color: rgba(255, 255, 255, 0.76);
+  color: var(--ink-700);
   font-size: 0.92rem;
 }
 
@@ -261,9 +310,10 @@ button:focus-visible {
   gap: 12px;
   min-height: 88px;
   border: 1px solid var(--border);
-  border-radius: 16px;
+  border-radius: var(--radius-md);
   padding: 16px;
-  background: rgba(255, 255, 255, 0.84);
+  background: rgba(255, 255, 255, 0.76);
+  box-shadow: none;
 }
 
 .path-number {
@@ -271,9 +321,10 @@ button:focus-visible {
   width: 40px;
   height: 40px;
   place-items: center;
+  border: 1px solid rgba(47, 75, 67, 0.12);
   border-radius: 50%;
-  background: var(--mist);
-  color: var(--pine-deep);
+  background: var(--sage-50);
+  color: var(--forest-900);
   font-weight: 900;
 }
 
@@ -283,12 +334,12 @@ button:focus-visible {
 }
 
 .path-step strong {
-  color: var(--pine-deep);
+  color: var(--forest-950);
 }
 
 .path-step small {
   margin-top: 2px;
-  color: var(--ink-soft);
+  color: var(--ink-700);
 }
 
 .docs-section {
@@ -297,61 +348,61 @@ button:focus-visible {
 
 .section-heading {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.75fr);
-  gap: 30px;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.78fr);
   align-items: end;
-  margin-bottom: 20px;
+  gap: 30px;
+  max-width: 1180px;
+  margin: 0 auto 20px;
 }
 
 .section-heading h2,
-.source-note h2 {
+.app-return h2 {
   margin: 0;
-  color: var(--pine-deep);
-  font-size: clamp(2rem, 4vw, 3.35rem);
+  color: var(--forest-950);
+  font-size: clamp(2rem, 4vw, 3.25rem);
   line-height: 1;
   letter-spacing: -0.045em;
 }
 
 .section-heading > p {
   margin: 0;
-  color: var(--ink-soft);
+  color: var(--ink-700);
 }
 
 .doc-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 14px;
-}
-
-.doc-grid-two {
   grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  max-width: 1180px;
+  margin: 0 auto;
 }
 
 .doc-card {
   display: flex;
-  min-height: 290px;
+  min-height: 260px;
   flex-direction: column;
   border: 1px solid var(--border);
-  border-radius: 18px;
+  border-radius: var(--radius-md);
   padding: 24px;
-  background: rgba(255, 255, 255, 0.92);
+  background: rgba(255, 255, 255, 0.76);
+  box-shadow: none;
 }
 
 .doc-card-featured {
-  border-color: rgba(95, 127, 115, 0.46);
-  background: linear-gradient(145deg, var(--mist), var(--white));
+  border-color: rgba(95, 127, 115, 0.48);
+  background: var(--sage-50);
 }
 
 .doc-card h3 {
   margin: 0;
-  color: var(--pine-deep);
+  color: var(--forest-950);
   font-size: 1.42rem;
   line-height: 1.15;
   letter-spacing: -0.025em;
 }
 
 .doc-card > p:not(.card-kicker) {
-  color: var(--ink-soft);
+  color: var(--ink-700);
 }
 
 .card-link {
@@ -362,99 +413,97 @@ button:focus-visible {
   margin-top: auto;
   border-top: 1px solid var(--border);
   padding-top: 16px;
-  color: var(--pine-deep);
-  text-decoration: none;
+  color: var(--forest-900);
   font-weight: 800;
+  text-decoration: none;
 }
 
 .card-link:hover {
-  color: var(--amber-deep);
+  color: var(--forest-700);
 }
 
 .safety-note,
-.source-note,
-.noscript-note {
-  margin-top: 28px;
-  border-radius: 16px;
+.app-return,
+.noscript-note,
+.document-return {
+  border-radius: var(--radius-md);
   padding: 20px 22px;
 }
 
 .safety-note {
-  border-left: 5px solid var(--amber-deep);
+  max-width: 1180px;
+  margin: 28px auto 0;
+  border-left: 5px solid var(--amber-600);
   background: #fff8ef;
 }
 
-.source-note {
-  display: grid;
-  grid-template-columns: minmax(0, 0.9fr) minmax(280px, 1.1fr);
-  gap: 28px;
+.app-return {
+  display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 28px;
+  max-width: 1180px;
+  margin: 28px auto 0;
   border: 1px solid var(--border);
-  background: var(--stone);
+  background: var(--sand-100);
 }
 
-.source-note p:last-child {
-  margin: 0;
-}
-
-.source-note code {
-  border-radius: 6px;
-  padding: 2px 6px;
-  background: var(--white);
-  color: var(--pine-deep);
+.app-return p:not(.eyebrow) {
+  max-width: 700px;
+  margin-bottom: 0;
+  color: var(--ink-700);
 }
 
 .document-view {
-  max-width: 920px;
+  max-width: var(--reading-width);
   margin: 0 auto;
-  padding-top: 30px;
+  padding-top: 12px;
 }
 
 .document-toolbar,
 .document-pager,
 .docs-footer {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
   justify-content: space-between;
-  gap: 16px;
 }
 
 .document-toolbar {
   border-bottom: 1px solid var(--border);
-  padding-bottom: 18px;
+  padding: 14px 0 18px;
 }
 
-.back-link,
-.source-link {
+.back-link {
   font-weight: 800;
   text-decoration: none;
 }
 
 .document-header {
-  margin: 46px 0 28px;
-  border-radius: 22px;
-  padding: clamp(28px, 6vw, 54px);
-  background: var(--pine-deep);
-  color: var(--white);
+  margin: 30px 0 28px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: clamp(30px, 6vw, 54px);
+  background:
+    radial-gradient(circle at 88% 12%, rgba(216, 181, 138, 0.2), transparent 31%),
+    linear-gradient(135deg, var(--sage-50), var(--sand-100));
+  color: var(--ink-900);
+  box-shadow: var(--shadow-sm);
 }
 
 .document-header h1 {
   max-width: 820px;
-  font-size: clamp(2.5rem, 6vw, 4.6rem);
+  font-size: clamp(2.45rem, 6vw, 4.35rem);
 }
 
 .document-header > p:last-child {
   max-width: 720px;
   margin: 18px 0 0;
-  color: rgba(255, 255, 255, 0.76);
+  color: var(--ink-700);
 }
 
 .document-status {
   border-radius: 12px;
   padding: 14px 16px;
-  background: var(--mist);
-  color: var(--pine-deep);
+  background: var(--sage-50);
+  color: var(--forest-900);
 }
 
 .document-status.is-error {
@@ -471,7 +520,7 @@ button:focus-visible {
 .markdown-body h2,
 .markdown-body h3,
 .markdown-body h4 {
-  color: var(--pine-deep);
+  color: var(--forest-950);
   line-height: 1.15;
   scroll-margin-top: 24px;
 }
@@ -496,11 +545,11 @@ button:focus-visible {
 
 .markdown-body blockquote {
   margin: 1.5em 0;
-  border-left: 4px solid var(--amber);
+  border-left: 4px solid var(--amber-500);
   border-radius: 0 12px 12px 0;
   padding: 0.8em 1.1em;
   background: #fff8ef;
-  color: var(--pine-deep);
+  color: var(--forest-950);
 }
 
 .markdown-body blockquote > :first-child {
@@ -529,23 +578,23 @@ button:focus-visible {
 }
 
 .markdown-body th {
-  background: var(--mist);
-  color: var(--pine-deep);
+  background: var(--sage-50);
+  color: var(--forest-950);
 }
 
 .markdown-body pre {
   overflow-x: auto;
   border-radius: 14px;
   padding: 18px;
-  background: var(--pine-deep);
+  background: var(--forest-950);
   color: #f7faf8;
 }
 
 .markdown-body :not(pre) > code {
   border-radius: 5px;
   padding: 2px 5px;
-  background: var(--mist);
-  color: var(--pine-deep);
+  background: var(--sage-50);
+  color: var(--forest-950);
 }
 
 .markdown-body hr {
@@ -571,82 +620,104 @@ button:focus-visible {
   text-decoration: none;
 }
 
+.document-return {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 28px;
+  border: 1px solid var(--border);
+  background: var(--sand-100);
+}
+
+.document-return p {
+  margin: 0;
+  color: var(--forest-950);
+  font-weight: 800;
+}
+
 .docs-footer {
   margin-top: 64px;
   border-top: 1px solid var(--border);
   padding-top: 22px;
-  color: var(--ink-soft);
+  color: var(--ink-700);
   font-size: 0.88rem;
 }
 
 .noscript-note {
+  max-width: 1180px;
+  margin: 28px auto 0;
   border-left: 4px solid var(--danger);
   background: #fff2ef;
+}
+
+.noscript-note p {
+  margin-top: 0;
 }
 
 [hidden] {
   display: none !important;
 }
 
-@media (max-width: 860px) {
-  .section-heading,
-  .source-note {
+@media (max-width: 900px) {
+  .hero-panel,
+  .section-heading {
     grid-template-columns: 1fr;
   }
 
-  .docs-header {
+  .app-return {
     align-items: flex-start;
     flex-direction: column;
   }
+}
 
-  .hero {
-    grid-template-columns: 1fr;
+@media (max-width: 780px) {
+  .site-header,
+  .docs-shell {
+    width: min(100% - 20px, var(--content-width));
   }
 
-  .doc-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .brand-tagline {
+    display: none;
+  }
+
+  .path-strip {
+    grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 640px) {
-  .docs-shell {
-    width: min(100% - 24px, var(--content-width));
-    padding-top: 12px;
-  }
-
-  .brand-link {
+  .site-header {
     align-items: flex-start;
     flex-direction: column;
-    gap: 5px;
+    gap: 12px;
   }
 
   .brand-logo {
-    width: min(238px, 78vw);
+    width: 176px;
   }
 
-  .docs-nav,
+  .site-header-actions,
   .hero-actions {
     width: 100%;
   }
 
-  .docs-nav .button,
+  .header-link,
   .hero-actions .button {
-    width: 100%;
+    flex: 1 1 auto;
   }
 
-  .hero {
-    border-radius: 18px;
+  .hero-panel {
+    border-radius: 20px;
     padding: 30px 22px;
   }
 
-  .path-strip,
-  .doc-grid,
-  .doc-grid-two {
+  .doc-grid {
     grid-template-columns: 1fr;
   }
 
   .doc-card {
-    min-height: 250px;
+    min-height: 235px;
   }
 
   .section-heading {
@@ -660,7 +731,8 @@ button:focus-visible {
 
   .document-toolbar,
   .document-pager,
-  .docs-footer {
+  .docs-footer,
+  .document-return {
     align-items: flex-start;
     flex-direction: column;
   }
@@ -670,8 +742,26 @@ button:focus-visible {
   }
 }
 
+@media (max-width: 420px) {
+  .site-header-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .header-link {
+    min-width: 0;
+    padding: 8px 9px;
+    font-size: 0.77rem;
+    text-align: center;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   html {
     scroll-behavior: auto;
+  }
+
+  .button {
+    transition: none;
   }
 }

--- a/docs/docs.js
+++ b/docs/docs.js
@@ -1,66 +1,38 @@
 (() => {
   "use strict";
 
-  const repositoryDocsUrl = "https://github.com/jeffthomasiii/pawpath/blob/main/docs/";
   const documents = [
     {
       slug: "why-pawpath",
       file: "WHY_PAWPATH.md",
       title: "Why PawPath?",
       eyebrow: "Product distinction",
-      description: "The problem PawPath solves, who it serves, and why the outcome must be a care plan rather than a list of places."
+      description: "The travel problem PawPath solves, who it serves, and why the outcome must be a care plan rather than a list of places."
     },
     {
       slug: "product-vision",
       file: "PRODUCT_VISION.md",
       title: "Product Vision",
-      eyebrow: "Direction",
-      description: "Mission, jobs to be done, core experiences, trust principles, success criteria, and long-term opportunity."
-    },
-    {
-      slug: "brand-guide",
-      file: "BRAND_GUIDE.md",
-      title: "Brand Guide",
-      eyebrow: "Brand source",
-      description: "The durable voice, visual, interaction, accessibility, and product-decision guidance for PawPath."
+      eyebrow: "Product direction",
+      description: "The mission, primary user needs, core experiences, trust principles, success criteria, and long-term opportunity."
     },
     {
       slug: "poc-scope",
       file: "POC_SCOPE.md",
       title: "Proof-of-Concept Scope",
-      eyebrow: "Requirements",
-      description: "The complete v0.2 demonstration outcome, required capabilities, acceptance criteria, and explicit non-goals."
+      eyebrow: "Current experience",
+      description: "The care-planning outcome, required workflows, safety boundaries, confidence model, acceptance criteria, and explicit non-goals."
     },
     {
       slug: "roadmap",
       file: "ROADMAP.md",
       title: "Roadmap",
-      eyebrow: "Product phases",
-      description: "The phased path from a care-plan proof of concept to stronger trust, route planning, offline readiness, and a broader platform."
-    },
-    {
-      slug: "backlog",
-      file: "BACKLOG.md",
-      title: "Phase 1 Backlog",
-      eyebrow: "Work packages",
-      description: "The implementation sequence and release gate for POC-01 through POC-09."
-    },
-    {
-      slug: "implementation-notes",
-      file: "IMPLEMENTATION_NOTES.md",
-      title: "Implementation Notes",
-      eyebrow: "Technical guidance",
-      description: "Practical architecture, state, storage, data-confidence, accessibility, and definition-of-done guidance for the static application."
-    },
-    {
-      slug: "demo-script",
-      file: "DEMO_SCRIPT.md",
-      title: "Demo Script",
-      eyebrow: "Product story",
-      description: "A focused walkthrough and feedback guide for proving that viewers understand the PawPath distinction."
+      eyebrow: "Future direction",
+      description: "The phased path from the care-plan proof of concept to stronger trust, multi-stop planning, offline readiness, and portable pet information."
     }
   ];
 
+  const blockedPublicReference = /chatgpt|brand[_\s-]?guide|phase\s*1\s*backlog|implementation[_\s-]?notes|demo[_\s-]?script/i;
   const home = document.querySelector("#docs-home");
   const documentView = document.querySelector("#document-view");
   const documentTitle = document.querySelector("#document-title");
@@ -68,7 +40,6 @@
   const documentDescription = document.querySelector("#document-description");
   const documentStatus = document.querySelector("#document-status");
   const markdownContent = document.querySelector("#markdown-content");
-  const sourceLink = document.querySelector("#document-source-link");
   const previousLink = document.querySelector("#previous-document");
   const nextLink = document.querySelector("#next-document");
   const homeLinks = document.querySelectorAll("[data-home-link]");
@@ -76,7 +47,7 @@
 
   const findDocumentByHash = () => {
     const slug = window.location.hash.replace(/^#/, "").trim();
-    return documents.find((document) => document.slug === slug) || null;
+    return documents.find((documentItem) => documentItem.slug === slug) || null;
   };
 
   const setHomeView = () => {
@@ -106,19 +77,47 @@
     }
   };
 
+  const removeBlockedReference = (link) => {
+    const parent = link.closest("li, p");
+    if (parent && parent.textContent.trim() === link.textContent.trim()) {
+      parent.remove();
+      return;
+    }
+    link.remove();
+  };
+
   const makeRenderedLinksSafe = () => {
     markdownContent.querySelectorAll("a[href]").forEach((link) => {
       const href = link.getAttribute("href") || "";
-      const matchingDocument = documents.find((document) => href.endsWith(document.file));
+      const label = link.textContent || "";
 
+      if (blockedPublicReference.test(`${href} ${label}`)) {
+        removeBlockedReference(link);
+        return;
+      }
+
+      const matchingDocument = documents.find((documentItem) => href.endsWith(documentItem.file));
       if (matchingDocument) {
         link.setAttribute("href", `#${matchingDocument.slug}`);
+        return;
+      }
+
+      if (/\.md(?:#.*)?$/i.test(href)) {
+        removeBlockedReference(link);
         return;
       }
 
       if (/^https?:\/\//i.test(href)) {
         link.setAttribute("target", "_blank");
         link.setAttribute("rel", "noopener noreferrer");
+      }
+    });
+  };
+
+  const removeBlockedRenderedSections = () => {
+    markdownContent.querySelectorAll("h1, h2, h3, h4, p, li").forEach((element) => {
+      if (blockedPublicReference.test(element.textContent || "")) {
+        element.remove();
       }
     });
   };
@@ -132,14 +131,12 @@
     documentTitle.textContent = doc.title;
     documentEyebrow.textContent = doc.eyebrow;
     documentDescription.textContent = doc.description;
-    sourceLink.href = `${repositoryDocsUrl}${doc.file}`;
     documentStatus.hidden = false;
     documentStatus.classList.remove("is-error");
     documentStatus.textContent = "Loading document…";
     markdownContent.replaceChildren();
     configurePager(doc);
     window.document.title = `${doc.title} | PawPath Documentation`;
-
     window.scrollTo({ top: 0, behavior: "auto" });
 
     try {
@@ -157,23 +154,19 @@
 
       const rendered = window.marked.parse(markdown, { gfm: true });
       markdownContent.innerHTML = window.DOMPurify.sanitize(rendered, { USE_PROFILES: { html: true } });
-
-      const firstHeading = markdownContent.querySelector("h1");
-      firstHeading?.remove();
-
+      markdownContent.querySelector("h1")?.remove();
+      removeBlockedRenderedSections();
       makeRenderedLinksSafe();
       documentStatus.hidden = true;
-      documentTitle.focus?.();
+      documentTitle.focus();
     } catch (error) {
       if (requestId !== renderRequest) return;
       documentStatus.hidden = false;
       documentStatus.classList.add("is-error");
       const message = document.createTextNode("The document could not be displayed here. ");
       const fallbackLink = document.createElement("a");
-      fallbackLink.href = `${repositoryDocsUrl}${doc.file}`;
-      fallbackLink.target = "_blank";
-      fallbackLink.rel = "noopener noreferrer";
-      fallbackLink.textContent = "Open the Markdown source on GitHub";
+      fallbackLink.href = doc.file;
+      fallbackLink.textContent = "Open the document directly";
       documentStatus.replaceChildren(message, fallbackLink, document.createTextNode("."));
       console.error("PawPath documentation render failed:", error);
     }

--- a/docs/docs.js
+++ b/docs/docs.js
@@ -32,7 +32,6 @@
     }
   ];
 
-  const blockedPublicReference = /chatgpt|brand[_\s-]?guide|phase\s*1\s*backlog|implementation[_\s-]?notes|demo[_\s-]?script/i;
   const home = document.querySelector("#docs-home");
   const documentView = document.querySelector("#document-view");
   const documentTitle = document.querySelector("#document-title");
@@ -89,12 +88,6 @@
   const makeRenderedLinksSafe = () => {
     markdownContent.querySelectorAll("a[href]").forEach((link) => {
       const href = link.getAttribute("href") || "";
-      const label = link.textContent || "";
-
-      if (blockedPublicReference.test(`${href} ${label}`)) {
-        removeBlockedReference(link);
-        return;
-      }
 
       const matchingDocument = documents.find((documentItem) => href.endsWith(documentItem.file));
       if (matchingDocument) {
@@ -110,14 +103,6 @@
       if (/^https?:\/\//i.test(href)) {
         link.setAttribute("target", "_blank");
         link.setAttribute("rel", "noopener noreferrer");
-      }
-    });
-  };
-
-  const removeBlockedRenderedSections = () => {
-    markdownContent.querySelectorAll("h1, h2, h3, h4, p, li").forEach((element) => {
-      if (blockedPublicReference.test(element.textContent || "")) {
-        element.remove();
       }
     });
   };
@@ -155,7 +140,6 @@
       const rendered = window.marked.parse(markdown, { gfm: true });
       markdownContent.innerHTML = window.DOMPurify.sanitize(rendered, { USE_PROFILES: { html: true } });
       markdownContent.querySelector("h1")?.remove();
-      removeBlockedRenderedSections();
       makeRenderedLinksSafe();
       documentStatus.hidden = true;
       documentTitle.focus();

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="PawPath product documentation, brand guidance, proof-of-concept scope, roadmap, implementation notes, and demo resources."
+      content="Learn why PawPath exists, how the pet-care preparedness workflow works, and what is planned for the product."
     />
     <meta name="theme-color" content="#2f4b43" />
     <title>PawPath Documentation</title>
@@ -15,51 +15,51 @@
   <body>
     <a class="skip-link" href="#main-content">Skip to main content</a>
 
-    <main id="main-content" class="docs-shell">
-      <header class="docs-header">
-        <a class="brand-link" href="../" aria-label="Back to the PawPath app">
-          <img class="brand-logo" src="../assets/PawPath_logo_Transparent.png" alt="PawPath" />
-          <span>Product documentation</span>
-        </a>
-        <nav class="docs-nav" aria-label="Documentation navigation">
-          <a class="button button-secondary" href="#home" data-home-link>Documentation home</a>
-          <a class="button button-primary" href="../">Back to app</a>
-        </nav>
-      </header>
+    <header class="site-header">
+      <a class="brand" href="../" aria-label="PawPath app home">
+        <img class="brand-logo" src="../assets/PawPath_logo_Transparent.png" alt="PawPath" />
+        <span class="brand-tagline">Pet-care preparedness for the road</span>
+      </a>
+      <nav class="site-header-actions" aria-label="Documentation navigation">
+        <a class="header-link" href="#home" data-home-link>Documentation home</a>
+        <a class="header-link header-link-primary" href="../">Back to app</a>
+      </nav>
+    </header>
 
+    <main id="main-content" class="docs-shell">
       <section id="docs-home" aria-labelledby="docs-title">
-        <section class="hero">
+        <section class="hero-panel">
           <div class="hero-copy">
             <p class="eyebrow">PawPath documentation</p>
             <h1 id="docs-title">Travel with a care plan.</h1>
             <p>
-              Product strategy, brand guidance, proof-of-concept requirements, roadmap, and implementation notes for
-              a calmer pet-care preparedness experience on the road.
+              Learn how PawPath helps people traveling with pets prepare veterinary care options before a trip and reach the
+              essential details quickly when something goes wrong.
             </p>
             <div class="hero-actions">
-              <a class="button button-primary" href="#why-pawpath">Start with why PawPath</a>
-              <a class="button button-secondary" href="#poc-scope">Review the POC scope</a>
-              <a class="button button-quiet" href="../">Open PawPath</a>
+              <a class="button button-primary" href="#why-pawpath">Why PawPath</a>
+              <a class="button button-secondary" href="#poc-scope">Explore the product scope</a>
+              <a class="button button-quiet" href="../">Return to PawPath</a>
             </div>
           </div>
-          <aside class="hero-callout" aria-label="Current product objective">
-            <p class="eyebrow">Current objective</p>
-            <strong>v0.2 — Care Plan POC</strong>
+          <aside class="hero-callout" aria-label="PawPath product promise">
+            <p class="eyebrow">Product promise</p>
+            <strong>Know where to turn before your pet needs care.</strong>
             <p>
-              Make it clear within two minutes that PawPath is a destination-based care-planning and emergency-readiness
-              workflow, not merely a veterinarian map.
+              Search around a destination, choose a Primary and Backup facility, save the plan, and keep immediate actions
+              close at hand.
             </p>
           </aside>
         </section>
 
-        <section class="path-strip" aria-label="PawPath product workflow">
+        <section class="path-strip" aria-label="PawPath care-plan workflow">
           <article class="path-step">
             <span class="path-number" aria-hidden="true">1</span>
-            <span><strong>Prepare</strong><small>Search the destination before the trip.</small></span>
+            <span><strong>Prepare</strong><small>Search around the destination before the trip.</small></span>
           </article>
           <article class="path-step">
             <span class="path-number" aria-hidden="true">2</span>
-            <span><strong>Choose</strong><small>Save a Primary and distinct Backup.</small></span>
+            <span><strong>Choose</strong><small>Select a Primary and a distinct Backup.</small></span>
           </article>
           <article class="path-step">
             <span class="path-number" aria-hidden="true">3</span>
@@ -70,83 +70,65 @@
         <section class="docs-section" aria-labelledby="foundation-title">
           <div class="section-heading">
             <div>
-              <p class="eyebrow">Start here</p>
-              <h2 id="foundation-title">Product foundation</h2>
+              <p class="eyebrow">Understand the product</p>
+              <h2 id="foundation-title">Why PawPath exists</h2>
             </div>
-            <p>Understand the problem, promise, audience, product principles, and approved brand direction.</p>
+            <p>
+              Start with the travel problem PawPath addresses, the people it serves, and the preparedness principles that
+              shape the experience.
+            </p>
           </div>
           <div class="doc-grid">
             <article class="doc-card doc-card-featured">
               <p class="card-kicker">Product distinction</p>
               <h3>Why PawPath?</h3>
-              <p>Why general maps are not enough, who PawPath serves, and the care-plan workflow that defines the product.</p>
+              <p>
+                See why a general map search is not the same as creating a pet-specific care plan for an unfamiliar
+                destination.
+              </p>
               <a class="card-link" href="#why-pawpath">Read why PawPath <span aria-hidden="true">→</span></a>
             </article>
             <article class="doc-card">
-              <p class="card-kicker">Direction</p>
+              <p class="card-kicker">Product direction</p>
               <h3>Product Vision</h3>
-              <p>Mission, jobs to be done, core experiences, trust model, principles, and proof-of-concept success criteria.</p>
-              <a class="card-link" href="#product-vision">Read the vision <span aria-hidden="true">→</span></a>
-            </article>
-            <article class="doc-card">
-              <p class="card-kicker">Brand source</p>
-              <h3>Brand Guide</h3>
-              <p>Voice, visual system, color use, interface shape strategy, accessibility, and the “trail guide” direction.</p>
-              <a class="card-link" href="#brand-guide">Read the brand guide <span aria-hidden="true">→</span></a>
+              <p>
+                Review the mission, primary user needs, Plan a Trip and Find Care Now workflows, trust principles, and
+                long-term opportunity.
+              </p>
+              <a class="card-link" href="#product-vision">Read the product vision <span aria-hidden="true">→</span></a>
             </article>
           </div>
         </section>
 
-        <section class="docs-section" aria-labelledby="poc-title">
+        <section class="docs-section" aria-labelledby="direction-title">
           <div class="section-heading">
             <div>
-              <p class="eyebrow">Build the shareable proof of concept</p>
-              <h2 id="poc-title">Scope and sequence</h2>
+              <p class="eyebrow">Scope and direction</p>
+              <h2 id="direction-title">How the product grows</h2>
             </div>
-            <p>Use these documents to define what belongs in v0.2, how it is ordered, and when the release is ready to share.</p>
+            <p>
+              Understand what the current proof of concept is designed to demonstrate and how future phases expand the
+              travel-care experience.
+            </p>
           </div>
           <div class="doc-grid">
             <article class="doc-card">
-              <p class="card-kicker">Requirements</p>
+              <p class="card-kicker">Current experience</p>
               <h3>Proof-of-Concept Scope</h3>
-              <p>The complete demonstration outcome, required capabilities, data strategy, acceptance criteria, and non-goals.</p>
-              <a class="card-link" href="#poc-scope">Review the POC scope <span aria-hidden="true">→</span></a>
+              <p>
+                Explore the care-planning outcome, required user workflows, confidence model, safety boundaries, and release
+                criteria.
+              </p>
+              <a class="card-link" href="#poc-scope">Review the product scope <span aria-hidden="true">→</span></a>
             </article>
             <article class="doc-card">
-              <p class="card-kicker">Work packages</p>
-              <h3>Phase 1 Backlog</h3>
-              <p>POC-01 through POC-09, arranged around product structure, care planning, emergency use, and validation.</p>
-              <a class="card-link" href="#backlog">Open the backlog <span aria-hidden="true">→</span></a>
-            </article>
-            <article class="doc-card">
-              <p class="card-kicker">Product phases</p>
+              <p class="card-kicker">Future direction</p>
               <h3>Roadmap</h3>
-              <p>The path from the Care Plan POC to trust, route planning, offline readiness, pet profiles, and a broader platform.</p>
+              <p>
+                Follow the path from the care-plan proof of concept to stronger facility trust, multi-stop planning, offline
+                readiness, and portable pet information.
+              </p>
               <a class="card-link" href="#roadmap">View the roadmap <span aria-hidden="true">→</span></a>
-            </article>
-          </div>
-        </section>
-
-        <section class="docs-section" aria-labelledby="delivery-title">
-          <div class="section-heading">
-            <div>
-              <p class="eyebrow">Deliver and demonstrate</p>
-              <h2 id="delivery-title">Implementation resources</h2>
-            </div>
-            <p>Translate product decisions into the static application and demonstrate the value without overstating its capabilities.</p>
-          </div>
-          <div class="doc-grid doc-grid-two">
-            <article class="doc-card">
-              <p class="card-kicker">Technical guidance</p>
-              <h3>Implementation Notes</h3>
-              <p>Data objects, state, local storage, confidence language, file evolution, accessibility, and the definition of done.</p>
-              <a class="card-link" href="#implementation-notes">Read implementation notes <span aria-hidden="true">→</span></a>
-            </article>
-            <article class="doc-card">
-              <p class="card-kicker">Product story</p>
-              <h3>Demo Script</h3>
-              <p>A two-to-three-minute walkthrough, a thirty-second version, viewer questions, and the validation signal that matters.</p>
-              <a class="card-link" href="#demo-script">Open the demo script <span aria-hidden="true">→</span></a>
             </article>
           </div>
         </section>
@@ -157,22 +139,20 @@
           specific pet or condition. Call ahead and confirm services, hours, species accepted, and availability.
         </section>
 
-        <section class="source-note" aria-label="Documentation source note">
+        <section class="app-return" aria-labelledby="app-return-title">
           <div>
-            <p class="eyebrow">Markdown remains the source of truth</p>
-            <h2>One documentation system, no duplicate editing.</h2>
+            <p class="eyebrow">Ready to explore?</p>
+            <h2 id="app-return-title">Make a care plan for your next trip.</h2>
+            <p>Return to PawPath to search a destination, review nearby care options, and save a Primary and Backup.</p>
           </div>
-          <p>
-            This page renders the Markdown files already maintained in <code>PawPath/docs</code>. Update those files and the
-            documentation view updates with them.
-          </p>
+          <a class="button button-primary" href="../">Back to the PawPath app</a>
         </section>
       </section>
 
       <section id="document-view" class="document-view" aria-labelledby="document-title" hidden>
         <div class="document-toolbar">
           <a class="back-link" href="#home"><span aria-hidden="true">←</span> Documentation home</a>
-          <a id="document-source-link" class="source-link" href="#" target="_blank" rel="noopener noreferrer">View Markdown on GitHub <span aria-hidden="true">↗</span></a>
+          <a class="back-link" href="../">Back to the PawPath app <span aria-hidden="true">↗</span></a>
         </div>
         <header class="document-header">
           <p id="document-eyebrow" class="eyebrow">PawPath documentation</p>
@@ -185,17 +165,26 @@
           <a id="previous-document" href="#"></a>
           <a id="next-document" href="#"></a>
         </nav>
+        <section class="document-return" aria-label="Return to PawPath">
+          <p>Ready to use PawPath?</p>
+          <a class="button button-primary" href="../">Back to the app</a>
+        </section>
       </section>
 
       <noscript>
         <section class="noscript-note">
-          JavaScript is needed to render the Markdown documents inside this page. The source files remain available in the
-          <a href="https://github.com/jeffthomasiii/pawpath/tree/main/docs">PawPath docs directory on GitHub</a>.
+          <p>JavaScript is needed to display the documents inside this page. You can open the public source documents directly:</p>
+          <ul>
+            <li><a href="WHY_PAWPATH.md">Why PawPath?</a></li>
+            <li><a href="PRODUCT_VISION.md">Product Vision</a></li>
+            <li><a href="POC_SCOPE.md">Proof-of-Concept Scope</a></li>
+            <li><a href="ROADMAP.md">Roadmap</a></li>
+          </ul>
         </section>
       </noscript>
 
       <footer class="docs-footer">
-        <span>PawPath product documentation</span>
+        <span>PawPath documentation</span>
         <span><a href="#home" data-home-link>Documentation home</a> · <a href="../">Back to app</a></span>
       </footer>
     </main>


### PR DESCRIPTION
## What changed

- Restyled `/docs/` to match the PawPath application’s light Pine, Sage, Stone, Amber, and Ink presentation
- Reworked the documentation header, light hero, buttons, workflow strip, cards, document headers, and return panels to follow the app’s current spacing, rounding, border, and emphasis patterns
- Reduced the public document set to exactly four sources: Why PawPath, Product Vision, Proof-of-Concept Scope, and Roadmap
- Removed public navigation, descriptions, routes, and source links for internal planning and delivery documents
- Removed the public GitHub source link and full repository-directory fallback
- Added clear routes back to the PawPath app in the header, hero, landing-page return panel, document toolbar, document footer panel, and site footer
- Kept all internal Markdown files unchanged in the repository
- Preserved sanitized Markdown rendering and removed links to any local Markdown file outside the four public documents

## Why this strengthens PawPath

The documentation now reads as a public extension of the product rather than an internal project workspace. It reinforces PawPath’s preparedness story, uses the same calm visual hierarchy as the app, and keeps implementation and project-management material out of the public navigation.

## Validation performed

- Confirmed the branch is based on the latest `main` and is not behind
- Confirmed the diff is limited to `docs/index.html`, `docs/docs.js`, and `docs/docs.css`
- Parsed the updated HTML and found no duplicate IDs
- Confirmed the public HTML, JavaScript, and CSS contain none of the removed document or project names
- Confirmed exactly four public Markdown documents are linked and routed
- Confirmed no public link points to GitHub or the complete repository docs directory
- Confirmed seven explicit links return users to the PawPath app across landing and document views
- Ran `node --check docs/docs.js`
- Confirmed CSS braces are balanced and responsive rules cover narrow layouts down to the repository’s 320px minimum width
- Confirmed the committed Git blob SHAs match the locally validated files

## Limitations and follow-up testing

- The repository and GitHub Pages site are public, so unlinked internal Markdown files are not access-controlled; this change removes them from the public documentation experience but does not make the source files private
- Deployed desktop, narrow-mobile, keyboard-focus, and Markdown-rendering review is still required because the repository has no automated browser-test suite

Closes #30