### PR TITLE
Refresh cached PawPath documentation assets

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,7 @@
     <meta name="theme-color" content="#2f4b43" />
     <title>PawPath Documentation</title>
     <link rel="icon" href="../assets/PawPath_mark_transparent.png" type="image/png" />
-    <link rel="stylesheet" href="docs.css" />
+    <link rel="stylesheet" href="docs.css?v=20260716-1" />
   </head>
   <body>
     <a class="skip-link" href="#main-content">Skip to main content</a>
@@ -191,6 +191,6 @@
 
     <script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js" defer></script>
-    <script src="docs.js" defer></script>
+    <script src="docs.js?v=20260716-1" defer></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
         <span class="brand-tagline">Pet-care preparedness for the road</span>
       </a>
       <div class="site-header-actions" aria-label="Site navigation">
-        <a class="header-link" href="docs/">Documentation</a>
+        <a class="header-link" href="docs/?v=20260716-1">Documentation</a>
         <span class="status-badge">Free map access</span>
       </div>
     </header>


### PR DESCRIPTION
## What changed

- Added a version query to the PawPath app’s Documentation link
- Added matching version queries to the public docs CSS and JavaScript assets
- Triggered a fresh Pages deployment without changing documentation content or application behavior

## Why

PR #31 is merged and the revised public documentation files are present on `main`, but the hosted site can continue serving previously cached HTML, CSS, or JavaScript. These versioned URLs force browsers and GitHub Pages edge caches to request the current public documentation experience.

## Validation

- Branch is based on the current `main` merge commit and is not behind
- Diff is limited to `index.html` and `docs/index.html`
- HTML parsing passed locally
- No JavaScript, CSS source, Markdown source, map, facility, care-plan, or storage behavior changed

Closes #32