### PR TITLE
Build full Emergency Mode

### DIFF
--- a/plan-summary.css
+++ b/plan-summary.css
@@ -10,48 +10,54 @@
   box-shadow: var(--shadow-sm);
 }
 
-.saved-plan-summary[hidden] {
+.saved-plan-summary[hidden],
+#saved-plan-standard[hidden],
+.emergency-mode-view[hidden] {
   display: none;
 }
 
 .saved-plan-summary.is-emergency-active {
-  border-color: rgba(163, 62, 50, 0.4);
-  background: linear-gradient(180deg, #fff5f2, var(--white));
-  box-shadow: 0 18px 48px rgba(163, 62, 50, 0.12);
+  border-color: rgba(95, 127, 115, 0.45);
+  background: linear-gradient(180deg, var(--sage-50), var(--white));
+  box-shadow: var(--shadow-md);
 }
 
-.saved-plan-summary-header {
+.saved-plan-summary-header,
+.emergency-mode-header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 20px;
 }
 
-.saved-plan-summary-header h2 {
+.saved-plan-summary-header h2,
+.emergency-mode-header h2 {
   margin: 3px 0 2px;
 }
 
-.saved-plan-destination {
+.saved-plan-destination,
+.emergency-mode-destination {
   margin: 0;
   color: var(--ink-500);
 }
 
 .saved-plan-emergency-button {
   flex: 0 0 auto;
-  border-color: var(--danger);
-  background: var(--danger);
+  border-color: var(--forest-900);
+  background: var(--forest-900);
   color: var(--white);
 }
 
 .saved-plan-emergency-button:hover,
 .saved-plan-emergency-button:focus-visible {
-  background: #862f27;
+  background: var(--forest-950);
 }
 
 .saved-plan-trip-meta {
   display: flex;
   flex-wrap: wrap;
   gap: 8px 14px;
+  margin-top: 18px;
   color: var(--ink-500);
   font-size: 0.8rem;
   font-weight: 700;
@@ -67,6 +73,7 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 14px;
+  margin-top: 18px;
 }
 
 .saved-facility-card {
@@ -79,15 +86,8 @@
   background: var(--white);
 }
 
-.saved-facility-card.is-primary {
-  border-color: rgba(163, 62, 50, 0.3);
-}
-
-.saved-facility-card.is-backup {
-  border-color: rgba(216, 148, 63, 0.4);
-}
-
-.saved-facility-card-heading {
+.saved-facility-card-heading,
+.emergency-facility-heading {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -134,6 +134,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 16px;
+  margin-top: 18px;
 }
 
 .saved-plan-secondary-actions {
@@ -148,19 +149,168 @@
   font-size: 0.76rem;
 }
 
+.emergency-mode-view {
+  display: grid;
+  gap: 18px;
+}
+
+.emergency-mode-header {
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.emergency-mode-exit {
+  flex: 0 0 auto;
+}
+
+.emergency-mode-guidance,
+.emergency-mode-disclaimer {
+  margin: 0;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--sage-50);
+  color: var(--ink-700);
+  line-height: 1.5;
+}
+
+.emergency-facility {
+  display: grid;
+  gap: 10px;
+  padding: clamp(18px, 3vw, 26px);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--white);
+}
+
+.emergency-facility.is-primary {
+  border-color: rgba(95, 127, 115, 0.58);
+  background: linear-gradient(180deg, var(--sage-50), var(--white));
+}
+
+.emergency-facility.is-backup {
+  border-color: rgba(216, 181, 138, 0.62);
+  background: #fbf8f3;
+}
+
+.emergency-facility h3 {
+  margin: 0;
+  color: var(--forest-950);
+  font-size: clamp(1.25rem, 3vw, 1.65rem);
+}
+
+.emergency-facility-address,
+.emergency-facility-distance {
+  margin: 0;
+  color: var(--ink-700);
+  line-height: 1.45;
+}
+
+.emergency-facility-distance {
+  font-weight: 700;
+}
+
+.emergency-facility-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.emergency-facility-actions.is-dominant .emergency-action {
+  min-height: 56px;
+  font-size: 1rem;
+}
+
+.emergency-action {
+  min-height: 46px;
+  justify-content: center;
+  text-align: center;
+}
+
+.emergency-action-unavailable {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 46px;
+  padding: 10px 14px;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--sand-100);
+  color: var(--ink-700);
+  font-weight: 700;
+  text-align: center;
+}
+
+.emergency-traveler-card {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: rgba(255,255,255,0.76);
+}
+
+.emergency-traveler-card h3 {
+  margin: 3px 0 0;
+}
+
+.emergency-traveler-details {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.emergency-traveler-details > div {
+  min-width: 0;
+  padding: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.emergency-traveler-details dt {
+  margin-bottom: 5px;
+  color: var(--ink-500);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.emergency-traveler-details dd {
+  margin: 0;
+  color: var(--ink-900);
+  overflow-wrap: anywhere;
+}
+
+body.is-emergency-mode .app-shell > :not(#saved-plan-summary) {
+  display: none !important;
+}
+
+body.is-emergency-mode .saved-plan-summary {
+  margin-top: 8px;
+}
+
+body.is-emergency-mode .site-footer {
+  display: none;
+}
+
 @media (max-width: 760px) {
   .saved-plan-summary-header,
-  .saved-plan-summary-footer {
+  .saved-plan-summary-footer,
+  .emergency-mode-header {
     align-items: stretch;
     flex-direction: column;
   }
 
-  .saved-plan-emergency-button {
+  .saved-plan-emergency-button,
+  .emergency-mode-exit {
     width: 100%;
     justify-content: center;
   }
 
-  .saved-plan-facilities {
+  .saved-plan-facilities,
+  .emergency-traveler-details {
     grid-template-columns: 1fr;
   }
 
@@ -179,13 +329,14 @@
     display: none;
   }
 
-  .saved-facility-actions {
-    align-items: stretch;
-    flex-direction: column;
+  .saved-facility-actions,
+  .emergency-facility-actions {
+    grid-template-columns: 1fr;
   }
 
-  .saved-facility-action {
-    justify-content: center;
+  .saved-facility-action,
+  .emergency-action,
+  .emergency-action-unavailable {
     width: 100%;
   }
 }

--- a/plan-summary.js
+++ b/plan-summary.js
@@ -2,6 +2,7 @@ const originalPersistCarePlanForSummary = persistCarePlan;
 const originalClearActiveCarePlanForSummary = clearActiveCarePlan;
 
 let planSummaryElements = {};
+let emergencyModeReturnTarget = null;
 
 persistCarePlan = function persistCarePlanWithSummary(message, announce = true) {
   originalPersistCarePlanForSummary(message, announce);
@@ -28,11 +29,18 @@ window.addEventListener("storage", (event) => {
   renderSavedPlanSummary();
 });
 
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape" && document.body.classList.contains("is-emergency-mode")) {
+    closeSavedPlanEmergencyMode();
+  }
+});
+
 function initializeSavedPlanSummary() {
   injectPlanSummaryRegion();
 
   planSummaryElements = {
     region: document.getElementById("saved-plan-summary"),
+    standard: document.getElementById("saved-plan-standard"),
     title: document.getElementById("saved-plan-title"),
     destination: document.getElementById("saved-plan-destination"),
     dates: document.getElementById("saved-plan-dates"),
@@ -42,6 +50,13 @@ function initializeSavedPlanSummary() {
     edit: document.getElementById("saved-plan-edit"),
     clear: document.getElementById("saved-plan-clear"),
     emergency: document.getElementById("saved-plan-emergency"),
+    emergencyView: document.getElementById("emergency-mode-view"),
+    emergencyTitle: document.getElementById("emergency-mode-title"),
+    emergencyDestination: document.getElementById("emergency-mode-destination"),
+    emergencyPrimary: document.getElementById("emergency-primary"),
+    emergencyBackup: document.getElementById("emergency-backup"),
+    emergencyTraveler: document.getElementById("emergency-traveler"),
+    emergencyExit: document.getElementById("emergency-mode-exit"),
     status: document.getElementById("saved-plan-status"),
   };
 
@@ -50,10 +65,11 @@ function initializeSavedPlanSummary() {
     if (clearActiveCarePlan()) announceSavedPlan("Saved plan cleared.");
   });
   planSummaryElements.emergency.addEventListener("click", openSavedPlanEmergencyMode);
+  planSummaryElements.emergencyExit.addEventListener("click", closeSavedPlanEmergencyMode);
 
   document.querySelectorAll(".mode-option").forEach((button) => {
     button.addEventListener("click", () => {
-      if (button.dataset.mode === "plan") resetSavedPlanEmergencyState();
+      if (document.body.classList.contains("is-emergency-mode")) closeSavedPlanEmergencyMode(false);
     });
   });
 
@@ -70,32 +86,61 @@ function injectPlanSummaryRegion() {
   region.setAttribute("aria-labelledby", "saved-plan-title");
 
   region.innerHTML = `
-    <div class="saved-plan-summary-header">
-      <div>
-        <p class="eyebrow">Active care plan</p>
-        <h2 id="saved-plan-title">Saved trip plan</h2>
-        <p id="saved-plan-destination" class="saved-plan-destination"></p>
+    <div id="saved-plan-standard">
+      <div class="saved-plan-summary-header">
+        <div>
+          <p class="eyebrow">Active care plan</p>
+          <h2 id="saved-plan-title">Saved trip plan</h2>
+          <p id="saved-plan-destination" class="saved-plan-destination"></p>
+        </div>
+        <button id="saved-plan-emergency" class="button saved-plan-emergency-button" type="button">
+          Open Emergency Mode
+        </button>
       </div>
-      <button id="saved-plan-emergency" class="button saved-plan-emergency-button" type="button">
-        Open Emergency Mode
-      </button>
-    </div>
 
-    <div class="saved-plan-trip-meta" aria-label="Saved trip details">
-      <span id="saved-plan-dates"></span>
-      <span id="saved-plan-pet"></span>
-      <span id="saved-plan-updated"></span>
-    </div>
-
-    <div id="saved-plan-facilities" class="saved-plan-facilities"></div>
-
-    <div class="saved-plan-summary-footer">
-      <div class="saved-plan-secondary-actions">
-        <button id="saved-plan-edit" class="text-button" type="button">Edit Plan</button>
-        <button id="saved-plan-clear" class="text-button is-destructive" type="button">Clear Plan</button>
+      <div class="saved-plan-trip-meta" aria-label="Saved trip details">
+        <span id="saved-plan-dates"></span>
+        <span id="saved-plan-pet"></span>
+        <span id="saved-plan-updated"></span>
       </div>
-      <p class="saved-plan-call-ahead">Call ahead to confirm services, hours, and availability.</p>
+
+      <div id="saved-plan-facilities" class="saved-plan-facilities"></div>
+
+      <div class="saved-plan-summary-footer">
+        <div class="saved-plan-secondary-actions">
+          <button id="saved-plan-edit" class="text-button" type="button">Edit Plan</button>
+          <button id="saved-plan-clear" class="text-button is-destructive" type="button">Clear Plan</button>
+        </div>
+        <p class="saved-plan-call-ahead">Call ahead to confirm services, hours, and availability.</p>
+      </div>
     </div>
+
+    <div id="emergency-mode-view" class="emergency-mode-view" hidden>
+      <header class="emergency-mode-header">
+        <div>
+          <p class="eyebrow">Emergency Mode</p>
+          <h2 id="emergency-mode-title">Use your saved care plan</h2>
+          <p id="emergency-mode-destination" class="emergency-mode-destination"></p>
+        </div>
+        <button id="emergency-mode-exit" class="button button-secondary emergency-mode-exit" type="button">Exit Emergency Mode</button>
+      </header>
+
+      <p class="emergency-mode-guidance"><strong>Call ahead:</strong> Confirm the facility is open, available, and able to treat your pet before driving when possible.</p>
+
+      <section id="emergency-primary" class="emergency-facility is-primary" aria-labelledby="emergency-primary-title"></section>
+      <section id="emergency-backup" class="emergency-facility is-backup" aria-labelledby="emergency-backup-title"></section>
+
+      <section class="emergency-traveler-card" aria-labelledby="emergency-traveler-title">
+        <div>
+          <p class="eyebrow">Saved trip details</p>
+          <h3 id="emergency-traveler-title">Pet and owner information</h3>
+        </div>
+        <dl id="emergency-traveler" class="emergency-traveler-details"></dl>
+      </section>
+
+      <p class="emergency-mode-disclaimer">PawPath does not diagnose conditions or guarantee facility hours, availability, services, or suitability for a specific pet.</p>
+    </div>
+
     <p id="saved-plan-status" class="sr-only" role="status" aria-live="polite"></p>
   `;
 
@@ -107,8 +152,8 @@ function renderSavedPlanSummary() {
   if (!planSummaryElements.region) return;
 
   if (!activeStoredPlan || !hasSavedCarePlan) {
+    closeSavedPlanEmergencyMode(false);
     planSummaryElements.region.hidden = true;
-    resetSavedPlanEmergencyState();
     planSummaryElements.facilities.innerHTML = "";
     return;
   }
@@ -126,12 +171,51 @@ function renderSavedPlanSummary() {
     createSavedFacilityCard("Primary", plan.facilities.primary, "primary"),
     createSavedFacilityCard("Backup", plan.facilities.backup, "backup")
   );
+
+  renderEmergencyMode(plan);
+}
+
+function renderEmergencyMode(plan) {
+  planSummaryElements.emergencyTitle.textContent = plan.trip.name;
+  planSummaryElements.emergencyDestination.textContent = plan.trip.destination;
+  renderEmergencyFacility(planSummaryElements.emergencyPrimary, plan.facilities.primary, "Primary", true);
+  renderEmergencyFacility(planSummaryElements.emergencyBackup, plan.facilities.backup, "Backup", false);
+
+  const details = [
+    ["Pet", plan.traveler.petName || "Not added"],
+    ["Owner phone", plan.traveler.ownerPhone || "Not added"],
+    ["Important note", plan.traveler.importantNote || "No note added"],
+  ];
+
+  planSummaryElements.emergencyTraveler.innerHTML = details
+    .map(([label, value]) => `<div><dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd></div>`)
+    .join("");
+}
+
+function renderEmergencyFacility(container, facility, role, dominant) {
+  const titleId = role === "Primary" ? "emergency-primary-title" : "emergency-backup-title";
+  const phoneMarkup = facility.phone
+    ? `<a class="button button-primary emergency-action" href="tel:${facility.phone.replace(/[^+\d]/g, "")}" aria-label="Call ${escapeHtml(facility.name)}">Call ${role}</a>`
+    : `<span class="emergency-action-unavailable" role="status">Phone not listed</span>`;
+
+  container.innerHTML = `
+    <div class="emergency-facility-heading">
+      <span class="selection-role-label ${role === "Primary" ? "is-primary" : "is-backup"}">${role}</span>
+      <span class="saved-facility-care-type">${escapeHtml(formatSavedCareType(facility.careType))}</span>
+    </div>
+    <h3 id="${titleId}">${escapeHtml(facility.name)}</h3>
+    <p class="emergency-facility-address">${escapeHtml(facility.address || "Address not listed")}</p>
+    <p class="emergency-facility-distance">${Number.isFinite(facility.distanceMiles) ? `${facility.distanceMiles.toFixed(1)} mi from saved destination` : "Distance unavailable"}</p>
+    <div class="emergency-facility-actions ${dominant ? "is-dominant" : ""}">
+      ${phoneMarkup}
+      <a class="button button-secondary emergency-action" href="${buildSavedFacilityDirectionsUrl(facility)}" target="_blank" rel="noopener noreferrer" aria-label="Open directions to ${escapeHtml(facility.name)}">Directions ↗</a>
+    </div>
+  `;
 }
 
 function createSavedFacilityCard(roleLabel, facility, role) {
   const card = document.createElement("article");
   card.className = `saved-facility-card is-${role}`;
-
   const roleClass = role === "primary" ? "is-primary" : "is-backup";
   const phoneAction = createFacilityPhoneAction(facility);
   const directionsAction = createFacilityDirectionsAction(facility);
@@ -150,13 +234,11 @@ function createSavedFacilityCard(roleLabel, facility, role) {
   const actions = card.querySelector(".saved-facility-actions");
   if (phoneAction) actions.append(phoneAction);
   actions.append(directionsAction);
-
   return card;
 }
 
 function createFacilityPhoneAction(facility) {
   if (!facility.phone) return null;
-
   const link = document.createElement("a");
   link.className = "button button-primary saved-facility-action";
   link.href = `tel:${facility.phone.replace(/[^+\d]/g, "")}`;
@@ -177,9 +259,8 @@ function createFacilityDirectionsAction(facility) {
 }
 
 function editSavedPlan() {
+  closeSavedPlanEmergencyMode(false);
   setMode("plan", true);
-  resetSavedPlanEmergencyState();
-
   const editor = document.getElementById("care-plan-editor");
   editor?.scrollIntoView({ behavior: prefersReducedMotion() ? "auto" : "smooth", block: "start" });
   window.setTimeout(() => document.getElementById("trip-name")?.focus({ preventScroll: true }), 250);
@@ -187,20 +268,44 @@ function editSavedPlan() {
 }
 
 function openSavedPlanEmergencyMode() {
+  if (!activeStoredPlan || !hasSavedCarePlan) {
+    announceSavedPlan("Save a valid care plan before opening Emergency Mode.");
+    return;
+  }
+
+  emergencyModeReturnTarget = document.activeElement instanceof HTMLElement ? document.activeElement : planSummaryElements.emergency;
   setMode("now", true);
+  document.body.classList.add("is-emergency-mode");
+  planSummaryElements.standard.hidden = true;
+  planSummaryElements.emergencyView.hidden = false;
   planSummaryElements.region.classList.add("is-emergency-active");
-  planSummaryElements.emergency.textContent = "Emergency Mode Active";
+  planSummaryElements.region.setAttribute("aria-labelledby", "emergency-mode-title");
   planSummaryElements.region.scrollIntoView({ behavior: prefersReducedMotion() ? "auto" : "smooth", block: "start" });
 
-  const firstCall = planSummaryElements.region.querySelector('.saved-facility-card.is-primary a[href^="tel:"]');
-  window.setTimeout(() => (firstCall || planSummaryElements.emergency).focus({ preventScroll: true }), 250);
-  announceSavedPlan("Emergency Mode opened. Primary and Backup call and directions actions are ready.");
+  const firstAction = planSummaryElements.emergencyPrimary.querySelector('a[href^="tel:"]') ||
+    planSummaryElements.emergencyPrimary.querySelector("a[href]") ||
+    planSummaryElements.emergencyExit;
+  window.setTimeout(() => firstAction.focus({ preventScroll: true }), 250);
+  announceSavedPlan("Emergency Mode opened. Primary actions are ready, with Backup immediately below.");
+}
+
+function closeSavedPlanEmergencyMode(restoreFocus = true) {
+  if (!planSummaryElements.region) return;
+  const wasOpen = document.body.classList.contains("is-emergency-mode");
+  document.body.classList.remove("is-emergency-mode");
+  planSummaryElements.region.classList.remove("is-emergency-active");
+  if (planSummaryElements.standard) planSummaryElements.standard.hidden = false;
+  if (planSummaryElements.emergencyView) planSummaryElements.emergencyView.hidden = true;
+  planSummaryElements.region.setAttribute("aria-labelledby", "saved-plan-title");
+
+  if (wasOpen && restoreFocus && emergencyModeReturnTarget?.isConnected) {
+    window.setTimeout(() => emergencyModeReturnTarget.focus({ preventScroll: true }), 0);
+  }
+  if (wasOpen) announceSavedPlan("Emergency Mode closed.");
 }
 
 function resetSavedPlanEmergencyState() {
-  if (!planSummaryElements.region || !planSummaryElements.emergency) return;
-  planSummaryElements.region.classList.remove("is-emergency-active");
-  planSummaryElements.emergency.textContent = "Open Emergency Mode";
+  closeSavedPlanEmergencyMode(false);
 }
 
 function announceSavedPlan(message) {


### PR DESCRIPTION
## Summary

- turns the saved-plan emergency transition into a focused Emergency Mode rather than a styled summary state
- presents the saved Primary facility first with large Call and Directions actions
- keeps the Backup facility immediately below without returning to search
- includes saved pet name, owner phone, and important note
- adds explicit call-ahead and availability guidance without diagnosis or treatment claims
- handles missing phone and address data honestly
- hides planning, search, filters, and map exploration while Emergency Mode is active
- supports Escape and an explicit Exit Emergency Mode control
- moves focus to the first Primary action on open and restores focus to the invoking control on close
- preserves the existing `pawpath.activeCarePlan.v1` storage schema and saved-plan module loading order

## Why this strengthens PawPath

Emergency Mode now demonstrates the core PawPath distinction: the user acts from a care plan they prepared before the trip instead of starting another map search during a stressful moment.

## Validation

- reviewed Issue #9 acceptance criteria against the implementation
- compared the feature branch against current `main`; only `plan-summary.js` and `plan-summary.css` changed
- confirmed no storage-schema, HTML-ID, map initialization, or base script-order changes
- confirmed dynamic content continues to use the existing HTML escaping helper
- confirmed Primary and Backup use the stored facility snapshots already validated by the care-plan module
- confirmed the branch is based directly on current `main`

## Browser testing still required

The repository has no automated browser-test suite. Deployed testing is still needed for saved-plan restoration, mobile layout, focus movement, Escape handling, `tel:` links, Google Maps directions, and transitions between Emergency Mode and the standard experience.

Closes #9