### PR TITLE
Build mobile web-app shell

### DIFF
--- a/docs/MOBILE_WEB_APP.md
+++ b/docs/MOBILE_WEB_APP.md
@@ -1,0 +1,53 @@
+# PawPath Mobile Web-App Direction
+
+## Purpose
+
+PawPath's mobile experience should behave like a purpose-built pet-care preparedness application rather than a desktop webpage compressed onto a phone.
+
+This phase remains a static web application hosted on GitHub Pages. It does not introduce a framework, backend, account system, build process, or native-app dependency.
+
+## Product model
+
+The mobile shell is organized around three persistent tasks:
+
+- **Plan** — prepare a destination-based care plan before travel.
+- **Care Now** — find nearby veterinary care with current-location emphasis.
+- **Saved** — reach the stored Primary and Backup facilities without scrolling through planning content.
+
+Emergency Mode remains a focused takeover entered from a valid saved plan.
+
+## Interface principles
+
+- Use a compact app header at phone widths instead of the full desktop site header.
+- Keep the approved PawPath Pine, Sage, Amber, Stone, Ink, and restrained Danger system.
+- Keep the interface visually distinct from Blue Green Guide; only the lesson of app-like task navigation carries over.
+- Prefer one primary mobile task surface at a time.
+- Treat Results and Map as switchable views rather than stacked page sections.
+- Keep saved-plan and emergency actions thumb-reachable.
+- Present facility details as a bottom sheet on narrow screens.
+- Preserve honest missing-data and call-ahead language.
+- Preserve keyboard access, focus visibility, and reduced-motion behavior.
+
+## Technical approach
+
+The mobile shell is layered on top of the existing PawPath application:
+
+- `mobile-app.css` contains phone-only app-shell presentation.
+- `mobile-app.js` injects the compact header, bottom navigation, saved-plan empty state, and Results/Map switcher.
+- `mobile-app-sync.js` keeps the mobile saved-plan indicators synchronized with the existing `pawpath.activeCarePlan.v1` persistence flow.
+- `map-layout-fix.js` loads the saved-plan module first, then the mobile shell, preserving the current global wrapper order.
+
+Desktop and tablet behavior remains governed by the existing application styles and modules.
+
+## Validation still required
+
+The repository has no automated browser-test suite. Deployed browser testing is required for:
+
+- iPhone Safari and Android Chrome narrow widths
+- safe-area padding and bottom navigation
+- Plan / Care Now / Saved navigation state
+- Results / Map switching and Leaflet resizing
+- saved-plan creation, clearing, restoration, and cross-tab updates
+- Emergency Mode entry and exit
+- facility-detail bottom-sheet scrolling and sticky actions
+- keyboard focus and reduced-motion behavior

--- a/map-layout-fix.js
+++ b/map-layout-fix.js
@@ -1,12 +1,24 @@
-/* Load the saved-plan summary after the core care-plan module is available. */
+/* Load late integration modules after the core care-plan module is available. */
 
 const planSummaryStylesheet = document.createElement("link");
 planSummaryStylesheet.rel = "stylesheet";
 planSummaryStylesheet.href = "plan-summary.css";
 document.head.append(planSummaryStylesheet);
 
+const mobileAppStylesheet = document.createElement("link");
+mobileAppStylesheet.rel = "stylesheet";
+mobileAppStylesheet.href = "mobile-app.css";
+document.head.append(mobileAppStylesheet);
+
 const planSummaryScript = document.createElement("script");
 planSummaryScript.src = "plan-summary.js";
+planSummaryScript.async = false;
+planSummaryScript.addEventListener("load", () => {
+  const mobileAppScript = document.createElement("script");
+  mobileAppScript.src = "mobile-app.js";
+  mobileAppScript.async = false;
+  document.head.append(mobileAppScript);
+});
 document.head.append(planSummaryScript);
 
 /* Keep Leaflet synchronized with responsive layout changes. */

--- a/map-layout-fix.js
+++ b/map-layout-fix.js
@@ -17,6 +17,12 @@ planSummaryScript.addEventListener("load", () => {
   const mobileAppScript = document.createElement("script");
   mobileAppScript.src = "mobile-app.js";
   mobileAppScript.async = false;
+  mobileAppScript.addEventListener("load", () => {
+    const mobileAppSyncScript = document.createElement("script");
+    mobileAppSyncScript.src = "mobile-app-sync.js";
+    mobileAppSyncScript.async = false;
+    document.head.append(mobileAppSyncScript);
+  });
   document.head.append(mobileAppScript);
 });
 document.head.append(planSummaryScript);

--- a/mobile-app-sync.js
+++ b/mobile-app-sync.js
@@ -1,0 +1,22 @@
+/* Keep the mobile shell synchronized with the existing care-plan globals. */
+
+const originalPersistCarePlanForMobileShell = persistCarePlan;
+const originalClearActiveCarePlanForMobileShell = clearActiveCarePlan;
+
+persistCarePlan = function persistCarePlanWithMobileShell(message, announce = true) {
+  const result = originalPersistCarePlanForMobileShell(message, announce);
+  window.setTimeout(syncMobileSavedPlanState, 0);
+  return result;
+};
+
+clearActiveCarePlan = function clearActiveCarePlanWithMobileShell() {
+  const result = originalClearActiveCarePlanForMobileShell();
+  window.setTimeout(syncMobileSavedPlanState, 0);
+  return result;
+};
+
+document.addEventListener("click", (event) => {
+  if (event.target.closest?.("#clear-care-plan")) {
+    window.setTimeout(syncMobileSavedPlanState, 0);
+  }
+});

--- a/mobile-app.css
+++ b/mobile-app.css
@@ -1,0 +1,516 @@
+/* PawPath mobile web-app shell. Desktop and tablet layouts remain unchanged. */
+
+.mobile-app-header,
+.mobile-bottom-nav,
+.mobile-discovery-switcher,
+.mobile-saved-empty {
+  display: none;
+}
+
+@media (max-width: 700px) {
+  :root {
+    --mobile-header-height: 64px;
+    --mobile-nav-height: 74px;
+  }
+
+  html,
+  body {
+    min-height: 100%;
+    background: var(--sand-50);
+  }
+
+  body {
+    padding: var(--mobile-header-height) 0 calc(var(--mobile-nav-height) + env(safe-area-inset-bottom));
+  }
+
+  body.is-emergency-mode {
+    padding: 0;
+  }
+
+  .site-header,
+  .site-footer {
+    display: none;
+  }
+
+  .mobile-app-header {
+    position: fixed;
+    z-index: 1200;
+    top: 0;
+    right: 0;
+    left: 0;
+    display: flex;
+    min-height: var(--mobile-header-height);
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 9px 14px;
+    border-bottom: 1px solid rgba(47, 75, 67, 0.12);
+    background: rgba(250, 249, 246, 0.94);
+    box-shadow: 0 4px 16px rgba(47, 75, 67, 0.06);
+    backdrop-filter: blur(18px);
+  }
+
+  .mobile-app-brand {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .mobile-app-brand img {
+    width: 37px;
+    height: 37px;
+    object-fit: contain;
+  }
+
+  .mobile-app-heading {
+    min-width: 0;
+  }
+
+  .mobile-app-heading strong,
+  .mobile-app-heading span {
+    display: block;
+  }
+
+  .mobile-app-heading strong {
+    overflow: hidden;
+    color: var(--forest-950);
+    font-size: 0.95rem;
+    line-height: 1.15;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mobile-app-heading span {
+    margin-top: 2px;
+    color: var(--ink-500);
+    font-size: 0.68rem;
+    font-weight: 700;
+  }
+
+  .mobile-emergency-shortcut {
+    min-height: 40px;
+    padding: 8px 11px;
+    border: 1px solid rgba(184, 95, 80, 0.3);
+    border-radius: 12px;
+    background: #f8eeeb;
+    color: #934a3f;
+    font: inherit;
+    font-size: 0.72rem;
+    font-weight: 800;
+    cursor: pointer;
+  }
+
+  .mobile-emergency-shortcut[hidden] {
+    display: none;
+  }
+
+  .app-shell {
+    width: 100%;
+    max-width: none;
+    gap: 0;
+    padding: 0;
+  }
+
+  .hero-panel,
+  .care-plan-editor,
+  .care-plan-selection,
+  .saved-plan-summary,
+  .discovery-layout {
+    border-right: 0;
+    border-left: 0;
+    border-radius: 0;
+    box-shadow: none;
+  }
+
+  .hero-panel {
+    display: block;
+    min-height: 0;
+    padding: 18px 16px 20px;
+    border-top: 0;
+    background: var(--sand-50);
+  }
+
+  .hero-panel::after,
+  .hero-copy,
+  .mode-selector,
+  .mode-guidance {
+    display: none;
+  }
+
+  .search-card {
+    display: grid;
+    gap: 10px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+    backdrop-filter: none;
+  }
+
+  .search-card > label {
+    color: var(--forest-950);
+    font-size: 1.05rem;
+    font-weight: 800;
+  }
+
+  .search-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 8px;
+  }
+
+  .input-wrap {
+    min-height: 48px;
+    border-radius: 14px;
+    background: var(--white);
+  }
+
+  #search-btn {
+    min-width: 48px;
+    min-height: 48px;
+    padding: 0 14px;
+    border-radius: 14px;
+  }
+
+  #search-button-label {
+    font-size: 0;
+  }
+
+  #search-button-label::after {
+    content: "Go";
+    font-size: 0.82rem;
+  }
+
+  #loc-btn {
+    grid-column: 1 / -1;
+    min-height: 44px;
+    border-radius: 14px;
+  }
+
+  .form-message {
+    margin: 0;
+    padding: 0 2px;
+    font-size: 0.76rem;
+  }
+
+  .care-plan-editor,
+  .care-plan-selection,
+  .saved-plan-summary {
+    padding: 20px 16px 24px;
+    border-top: 1px solid var(--border);
+    background: var(--sand-50);
+  }
+
+  .care-plan-editor-heading,
+  .care-plan-selection-heading,
+  .saved-plan-summary-header {
+    gap: 10px;
+  }
+
+  .care-plan-editor-heading,
+  .care-plan-selection-heading {
+    display: block;
+  }
+
+  .care-plan-editor-heading > div:last-child,
+  .care-plan-selection-heading > p {
+    margin-top: 10px;
+  }
+
+  .care-plan-fields {
+    grid-template-columns: 1fr;
+  }
+
+  .selection-slots,
+  .saved-plan-facilities {
+    grid-template-columns: 1fr;
+  }
+
+  .discovery-layout {
+    position: relative;
+    display: block;
+    height: calc(100dvh - var(--mobile-header-height) - var(--mobile-nav-height));
+    min-height: 520px;
+    overflow: hidden;
+    border-top: 1px solid var(--border);
+    background: var(--white);
+  }
+
+  .mobile-discovery-switcher {
+    position: absolute;
+    z-index: 800;
+    top: 10px;
+    left: 50%;
+    display: grid;
+    width: min(244px, calc(100% - 32px));
+    grid-template-columns: 1fr 1fr;
+    gap: 4px;
+    padding: 4px;
+    border: 1px solid rgba(47, 75, 67, 0.14);
+    border-radius: 14px;
+    background: rgba(250, 249, 246, 0.94);
+    box-shadow: 0 5px 18px rgba(47, 75, 67, 0.1);
+    transform: translateX(-50%);
+    backdrop-filter: blur(14px);
+  }
+
+  .mobile-discovery-button {
+    min-height: 38px;
+    border: 0;
+    border-radius: 10px;
+    background: transparent;
+    color: var(--ink-700);
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 800;
+    cursor: pointer;
+  }
+
+  .mobile-discovery-button.is-active {
+    background: var(--white);
+    color: var(--forest-950);
+    box-shadow: 0 2px 8px rgba(47, 75, 67, 0.08);
+  }
+
+  .results-panel,
+  .map-panel {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    border: 0;
+  }
+
+  .results-panel {
+    overflow-y: auto;
+    padding: 66px 14px 20px;
+    background: var(--sand-50);
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .results-heading {
+    align-items: flex-start;
+  }
+
+  .results-heading h2 {
+    font-size: 1.12rem;
+  }
+
+  .filter-row {
+    position: sticky;
+    z-index: 3;
+    top: -1px;
+    padding: 8px 0;
+    background: rgba(250, 249, 246, 0.96);
+    backdrop-filter: blur(10px);
+  }
+
+  .clinic-list {
+    padding-bottom: 16px;
+  }
+
+  .map-panel {
+    display: block;
+  }
+
+  .map-note {
+    right: 12px;
+    bottom: 12px;
+    left: 12px;
+    max-width: none;
+    font-size: 0.67rem;
+  }
+
+  body[data-mobile-discovery="results"] .map-panel,
+  body[data-mobile-discovery="map"] .results-panel {
+    visibility: hidden;
+    pointer-events: none;
+  }
+
+  body[data-mobile-view="saved"] #hero-panel,
+  body[data-mobile-view="saved"] #care-plan-editor,
+  body[data-mobile-view="saved"] #care-plan-selection,
+  body[data-mobile-view="saved"] .discovery-layout {
+    display: none !important;
+  }
+
+  body[data-mobile-view="plan"] .saved-plan-summary,
+  body[data-mobile-view="care"] .saved-plan-summary,
+  body[data-mobile-view="plan"] .mobile-saved-empty,
+  body[data-mobile-view="care"] .mobile-saved-empty {
+    display: none !important;
+  }
+
+  body[data-mobile-view="care"] #care-plan-editor,
+  body[data-mobile-view="care"] #care-plan-selection {
+    display: none !important;
+  }
+
+  body[data-mobile-view="saved"] .saved-plan-summary:not([hidden]),
+  body[data-mobile-view="saved"] .mobile-saved-empty:not([hidden]) {
+    display: block;
+  }
+
+  .mobile-saved-empty {
+    min-height: calc(100dvh - var(--mobile-header-height) - var(--mobile-nav-height));
+    padding: 44px 22px;
+    border-top: 1px solid var(--border);
+    background: var(--sand-50);
+    text-align: center;
+  }
+
+  .mobile-saved-empty h2 {
+    margin: 12px 0 8px;
+    color: var(--forest-950);
+    font-size: 1.35rem;
+  }
+
+  .mobile-saved-empty p {
+    margin: 0 auto 18px;
+    max-width: 320px;
+    color: var(--ink-700);
+    line-height: 1.55;
+  }
+
+  .mobile-saved-empty-mark {
+    display: grid;
+    width: 54px;
+    height: 54px;
+    margin: 0 auto;
+    place-items: center;
+    border-radius: 18px;
+    background: var(--sage-100);
+    color: var(--forest-900);
+    font-size: 1.45rem;
+  }
+
+  .mobile-bottom-nav {
+    position: fixed;
+    z-index: 1200;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    display: grid;
+    min-height: var(--mobile-nav-height);
+    grid-template-columns: repeat(3, 1fr);
+    padding: 6px 8px calc(7px + env(safe-area-inset-bottom));
+    border-top: 1px solid rgba(47, 75, 67, 0.14);
+    background: rgba(250, 249, 246, 0.96);
+    box-shadow: 0 -5px 20px rgba(47, 75, 67, 0.07);
+    backdrop-filter: blur(18px);
+  }
+
+  .mobile-nav-button {
+    display: grid;
+    min-height: 56px;
+    place-items: center;
+    align-content: center;
+    gap: 3px;
+    border: 0;
+    border-radius: 14px;
+    background: transparent;
+    color: var(--ink-500);
+    font: inherit;
+    cursor: pointer;
+  }
+
+  .mobile-nav-button.is-active {
+    background: var(--sage-50);
+    color: var(--forest-950);
+  }
+
+  .mobile-nav-icon {
+    font-size: 1.05rem;
+    font-weight: 900;
+    line-height: 1;
+  }
+
+  .mobile-nav-label {
+    font-size: 0.68rem;
+    font-weight: 800;
+  }
+
+  .mobile-nav-dot {
+    position: absolute;
+    width: 7px;
+    height: 7px;
+    margin: -36px 0 0 28px;
+    border: 2px solid var(--sand-50);
+    border-radius: 999px;
+    background: var(--danger);
+  }
+
+  .mobile-nav-dot[hidden] {
+    display: none;
+  }
+
+  .facility-detail {
+    width: 100vw;
+    max-height: calc(100dvh - 10px);
+    margin: auto 0 0;
+    border-radius: 22px 22px 0 0;
+  }
+
+  .facility-detail-shell {
+    max-height: calc(100dvh - 10px);
+    padding-top: 18px;
+  }
+
+  .facility-detail-header::before {
+    position: absolute;
+    top: 7px;
+    left: 50%;
+    width: 42px;
+    height: 4px;
+    border-radius: 999px;
+    background: var(--border);
+    content: "";
+    transform: translateX(-50%);
+  }
+
+  .facility-detail-header {
+    position: relative;
+    padding-top: 8px;
+  }
+
+  .facility-detail-actions {
+    padding-bottom: calc(18px + env(safe-area-inset-bottom));
+  }
+
+  body.is-emergency-mode .mobile-app-header,
+  body.is-emergency-mode .mobile-bottom-nav,
+  body.is-emergency-mode .mobile-saved-empty {
+    display: none !important;
+  }
+
+  body.is-emergency-mode .app-shell {
+    min-height: 100dvh;
+  }
+
+  body.is-emergency-mode .saved-plan-summary.is-emergency-active {
+    min-height: 100dvh;
+    padding: max(18px, env(safe-area-inset-top)) 16px max(24px, env(safe-area-inset-bottom));
+    border: 0;
+  }
+
+  body.is-emergency-mode .emergency-mode-view {
+    min-height: calc(100dvh - 42px);
+  }
+
+  .mobile-nav-button:focus-visible,
+  .mobile-discovery-button:focus-visible,
+  .mobile-emergency-shortcut:focus-visible {
+    outline: 3px solid rgba(95, 127, 115, 0.46);
+    outline-offset: 2px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mobile-app-header,
+  .mobile-bottom-nav,
+  .mobile-discovery-switcher {
+    scroll-behavior: auto;
+  }
+}

--- a/mobile-app.js
+++ b/mobile-app.js
@@ -1,0 +1,258 @@
+const MOBILE_APP_QUERY = window.matchMedia("(max-width: 700px)");
+
+const originalSetModeForMobileApp = setMode;
+let mobileAppElements = {};
+let mobileView = activeMode === "now" ? "care" : "plan";
+let mobileDiscoveryView = "results";
+
+setMode = function setModeWithMobileApp(mode, announce = false) {
+  originalSetModeForMobileApp(mode, announce);
+  if (!MOBILE_APP_QUERY.matches || document.body.classList.contains("is-emergency-mode")) return;
+  setMobileView(mode === "now" ? "care" : "plan", false);
+};
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initializeMobileAppShell);
+} else {
+  initializeMobileAppShell();
+}
+
+window.addEventListener("storage", (event) => {
+  if (event.key === CARE_PLAN_STORAGE_KEY) window.setTimeout(syncMobileSavedPlanState, 0);
+});
+
+function initializeMobileAppShell() {
+  injectMobileAppHeader();
+  injectMobileBottomNavigation();
+  injectMobileDiscoverySwitcher();
+  injectMobileSavedEmptyState();
+
+  mobileAppElements = {
+    header: document.getElementById("mobile-app-header"),
+    heading: document.getElementById("mobile-app-title"),
+    context: document.getElementById("mobile-app-context"),
+    emergency: document.getElementById("mobile-emergency-shortcut"),
+    navButtons: [...document.querySelectorAll(".mobile-nav-button[data-mobile-view]")],
+    savedDot: document.getElementById("mobile-saved-dot"),
+    discoveryButtons: [...document.querySelectorAll(".mobile-discovery-button[data-mobile-discovery]")],
+    savedEmpty: document.getElementById("mobile-saved-empty"),
+    savedEmptyPlan: document.getElementById("mobile-saved-empty-plan"),
+  };
+
+  mobileAppElements.navButtons.forEach((button) => {
+    button.addEventListener("click", () => handleMobileNavigation(button.dataset.mobileView));
+  });
+
+  mobileAppElements.discoveryButtons.forEach((button) => {
+    button.addEventListener("click", () => setMobileDiscoveryView(button.dataset.mobileDiscovery));
+  });
+
+  mobileAppElements.emergency.addEventListener("click", () => {
+    const openEmergencyButton = document.getElementById("saved-plan-emergency");
+    if (openEmergencyButton && !openEmergencyButton.closest("[hidden]")) {
+      openEmergencyButton.click();
+    }
+  });
+
+  mobileAppElements.savedEmptyPlan.addEventListener("click", () => {
+    setMode("plan", true);
+    setMobileView("plan");
+  });
+
+  MOBILE_APP_QUERY.addEventListener?.("change", handleMobileBreakpointChange);
+
+  const appShell = document.getElementById("main-content");
+  if (appShell && "MutationObserver" in window) {
+    const observer = new MutationObserver(syncMobileSavedPlanState);
+    observer.observe(appShell, { childList: true, subtree: false });
+  }
+
+  document.addEventListener("click", (event) => {
+    const emergencyExit = event.target.closest?.("#emergency-mode-exit");
+    if (emergencyExit) window.setTimeout(() => setMobileView("saved", false), 0);
+  });
+
+  setMobileDiscoveryView("results", false);
+  setMobileView(activeMode === "now" ? "care" : "plan", false);
+  syncMobileSavedPlanState();
+}
+
+function injectMobileAppHeader() {
+  if (document.getElementById("mobile-app-header")) return;
+  const header = document.createElement("header");
+  header.id = "mobile-app-header";
+  header.className = "mobile-app-header";
+  header.innerHTML = `
+    <div class="mobile-app-brand">
+      <img src="assets/PawPath_mark_transparent.png" alt="" aria-hidden="true" />
+      <div class="mobile-app-heading">
+        <strong id="mobile-app-title">Plan</strong>
+        <span id="mobile-app-context">Travel with a care plan</span>
+      </div>
+    </div>
+    <button id="mobile-emergency-shortcut" class="mobile-emergency-shortcut" type="button" hidden>
+      Emergency
+    </button>
+  `;
+  document.body.insertBefore(header, document.querySelector(".site-header"));
+}
+
+function injectMobileBottomNavigation() {
+  if (document.getElementById("mobile-bottom-nav")) return;
+  const nav = document.createElement("nav");
+  nav.id = "mobile-bottom-nav";
+  nav.className = "mobile-bottom-nav";
+  nav.setAttribute("aria-label", "PawPath mobile navigation");
+  nav.innerHTML = `
+    <button class="mobile-nav-button is-active" type="button" data-mobile-view="plan" aria-current="page">
+      <span class="mobile-nav-icon" aria-hidden="true">⌖</span>
+      <span class="mobile-nav-label">Plan</span>
+    </button>
+    <button class="mobile-nav-button" type="button" data-mobile-view="care">
+      <span class="mobile-nav-icon" aria-hidden="true">✚</span>
+      <span class="mobile-nav-label">Care Now</span>
+    </button>
+    <button class="mobile-nav-button" type="button" data-mobile-view="saved">
+      <span class="mobile-nav-icon" aria-hidden="true">✓</span>
+      <span class="mobile-nav-label">Saved</span>
+      <span id="mobile-saved-dot" class="mobile-nav-dot" hidden aria-hidden="true"></span>
+    </button>
+  `;
+  document.body.append(nav);
+}
+
+function injectMobileDiscoverySwitcher() {
+  const discovery = document.querySelector(".discovery-layout");
+  if (!discovery || document.getElementById("mobile-discovery-switcher")) return;
+  const switcher = document.createElement("div");
+  switcher.id = "mobile-discovery-switcher";
+  switcher.className = "mobile-discovery-switcher";
+  switcher.setAttribute("role", "group");
+  switcher.setAttribute("aria-label", "Choose care results or map view");
+  switcher.innerHTML = `
+    <button class="mobile-discovery-button is-active" type="button" data-mobile-discovery="results" aria-pressed="true">Results</button>
+    <button class="mobile-discovery-button" type="button" data-mobile-discovery="map" aria-pressed="false">Map</button>
+  `;
+  discovery.prepend(switcher);
+}
+
+function injectMobileSavedEmptyState() {
+  if (document.getElementById("mobile-saved-empty")) return;
+  const section = document.createElement("section");
+  section.id = "mobile-saved-empty";
+  section.className = "mobile-saved-empty";
+  section.hidden = true;
+  section.innerHTML = `
+    <span class="mobile-saved-empty-mark" aria-hidden="true">✓</span>
+    <h2>No saved care plan yet</h2>
+    <p>Choose a Primary and Backup facility and save your trip details. Your plan will stay available here on this device.</p>
+    <button id="mobile-saved-empty-plan" class="button button-primary" type="button">Build a care plan</button>
+  `;
+  const hero = document.getElementById("hero-panel");
+  hero?.insertAdjacentElement("afterend", section);
+}
+
+function handleMobileNavigation(view) {
+  if (!MOBILE_APP_QUERY.matches) return;
+  if (document.body.classList.contains("is-emergency-mode") && typeof closeSavedPlanEmergencyMode === "function") {
+    closeSavedPlanEmergencyMode(false);
+  }
+
+  if (view === "plan") {
+    setMode("plan", true);
+    setMobileView("plan");
+    return;
+  }
+
+  if (view === "care") {
+    setMode("now", true);
+    setMobileView("care");
+    return;
+  }
+
+  setMobileView("saved");
+}
+
+function setMobileView(view, moveFocus = true) {
+  if (!["plan", "care", "saved"].includes(view)) return;
+  mobileView = view;
+  document.body.dataset.mobileView = view;
+
+  mobileAppElements.navButtons?.forEach((button) => {
+    const active = button.dataset.mobileView === view;
+    button.classList.toggle("is-active", active);
+    if (active) button.setAttribute("aria-current", "page");
+    else button.removeAttribute("aria-current");
+  });
+
+  const labels = {
+    plan: ["Plan", "Prepare before you leave"],
+    care: ["Care Now", "Find nearby veterinary care"],
+    saved: ["Saved Plan", "Your Primary and Backup"],
+  };
+  if (mobileAppElements.heading) mobileAppElements.heading.textContent = labels[view][0];
+  if (mobileAppElements.context) mobileAppElements.context.textContent = labels[view][1];
+
+  syncMobileSavedPlanState();
+  if (view !== "saved") setMobileDiscoveryView("results", false);
+
+  if (view === "saved" && moveFocus) {
+    window.setTimeout(() => {
+      const target = document.getElementById("saved-plan-emergency") || document.getElementById("mobile-saved-empty-plan");
+      target?.focus({ preventScroll: true });
+    }, 0);
+  }
+
+  window.scrollTo({ top: 0, behavior: prefersReducedMotion?.() ? "auto" : "smooth" });
+}
+
+function setMobileDiscoveryView(view, moveFocus = false) {
+  if (!["results", "map"].includes(view)) return;
+  mobileDiscoveryView = view;
+  document.body.dataset.mobileDiscovery = view;
+
+  mobileAppElements.discoveryButtons?.forEach((button) => {
+    const active = button.dataset.mobileDiscovery === view;
+    button.classList.toggle("is-active", active);
+    button.setAttribute("aria-pressed", String(active));
+  });
+
+  if (view === "map") {
+    window.setTimeout(() => {
+      if (typeof map !== "undefined" && map?.invalidateSize) map.invalidateSize({ pan: false });
+    }, 80);
+  }
+
+  if (moveFocus) {
+    const panel = view === "results" ? document.querySelector(".results-panel") : document.getElementById("map");
+    panel?.focus?.({ preventScroll: true });
+  }
+}
+
+function syncMobileSavedPlanState() {
+  if (!mobileAppElements.savedEmpty) return;
+  const savedRegion = document.getElementById("saved-plan-summary");
+  const hasPlan = Boolean(typeof hasSavedCarePlan !== "undefined" && hasSavedCarePlan && activeStoredPlan);
+
+  mobileAppElements.savedEmpty.hidden = hasPlan;
+  if (mobileAppElements.savedDot) mobileAppElements.savedDot.hidden = !hasPlan;
+  if (mobileAppElements.emergency) mobileAppElements.emergency.hidden = !hasPlan;
+
+  if (savedRegion && mobileView === "saved") {
+    savedRegion.hidden = !hasPlan;
+  }
+}
+
+function handleMobileBreakpointChange(event) {
+  if (event.matches) {
+    setMobileView(activeMode === "now" ? "care" : "plan", false);
+    setMobileDiscoveryView(mobileDiscoveryView, false);
+    syncMobileSavedPlanState();
+    return;
+  }
+
+  document.body.removeAttribute("data-mobile-view");
+  document.body.removeAttribute("data-mobile-discovery");
+  const savedRegion = document.getElementById("saved-plan-summary");
+  if (savedRegion && typeof hasSavedCarePlan !== "undefined") savedRegion.hidden = !hasSavedCarePlan;
+}


### PR DESCRIPTION
## Summary

- adds a phone-only PawPath application shell without replacing the desktop/tablet layout
- adds a compact mobile app header with a saved-plan Emergency shortcut
- adds persistent bottom navigation for Plan, Care Now, and Saved Plan
- keeps bottom-nav state synchronized with the existing Plan a Trip / Find Care Now mode system
- adds a Saved Plan destination that is reachable without scrolling through the page, including an empty state when no plan exists
- turns Results and Map into switchable mobile task views instead of stacking both vertically
- refines the existing facility detail drawer into a near-full-height mobile bottom sheet
- presents Emergency Mode as a full-height mobile takeover and hides ordinary app chrome while active
- preserves the existing `pawpath.activeCarePlan.v1` storage schema, search behavior, care-plan logic, and desktop experience
- adds durable mobile web-app direction documentation

## Why this strengthens PawPath

This moves the narrow-screen experience from a responsive desktop webpage toward a purpose-built travel-care application. PawPath remains visually distinct and preparedness-first: the primary mobile destinations are planning, immediate care, and the saved Primary/Backup plan rather than generic site navigation.

## Technical approach

- `mobile-app.css` contains phone-only shell and task-view styling
- `mobile-app.js` injects mobile app chrome, bottom navigation, saved-plan empty state, and the Results/Map switcher
- `mobile-app-sync.js` keeps saved-plan indicators synchronized with the existing persistence wrappers
- `map-layout-fix.js` preserves script order by loading the saved-plan module first, then the mobile shell modules
- no framework, backend, build system, account model, or native dependency is introduced

## Validation

- compared the feature branch against current `main`
- confirmed the branch is based directly on the current merged Emergency Mode baseline
- confirmed existing HTML IDs, local-storage schema, Leaflet initialization, and core search modules are unchanged
- confirmed mobile app behavior is scoped to `max-width: 700px`
- confirmed desktop and tablet presentation remain under the existing CSS paths
- confirmed Emergency Mode still uses the existing saved-plan workflow and becomes a full-height mobile takeover

## Browser testing still required

The repository has no automated browser-test suite. Deployed testing is required on narrow mobile widths, especially iPhone Safari and Android Chrome, for safe-area padding, bottom navigation, Results/Map switching, Leaflet resizing, saved-plan restore/clear behavior, facility-sheet scrolling, Emergency Mode, and keyboard focus.

Closes #36