### PR TITLE
Refine mobile Plan into guided steps

### DIFF
--- a/map-layout-fix.js
+++ b/map-layout-fix.js
@@ -10,6 +10,11 @@ mobileAppStylesheet.rel = "stylesheet";
 mobileAppStylesheet.href = "mobile-app.css";
 document.head.append(mobileAppStylesheet);
 
+const mobilePlanStylesheet = document.createElement("link");
+mobilePlanStylesheet.rel = "stylesheet";
+mobilePlanStylesheet.href = "mobile-plan.css";
+document.head.append(mobilePlanStylesheet);
+
 const planSummaryScript = document.createElement("script");
 planSummaryScript.src = "plan-summary.js";
 planSummaryScript.async = false;
@@ -21,6 +26,12 @@ planSummaryScript.addEventListener("load", () => {
     const mobileAppSyncScript = document.createElement("script");
     mobileAppSyncScript.src = "mobile-app-sync.js";
     mobileAppSyncScript.async = false;
+    mobileAppSyncScript.addEventListener("load", () => {
+      const mobilePlanScript = document.createElement("script");
+      mobilePlanScript.src = "mobile-plan.js";
+      mobilePlanScript.async = false;
+      document.head.append(mobilePlanScript);
+    });
     document.head.append(mobileAppSyncScript);
   });
   document.head.append(mobileAppScript);

--- a/mobile-plan.css
+++ b/mobile-plan.css
@@ -1,0 +1,319 @@
+/* Guided mobile Plan workflow. Desktop/tablet remain unchanged. */
+
+.mobile-plan-stepper,
+.mobile-plan-review,
+.mobile-plan-stage-actions {
+  display: none;
+}
+
+@media (max-width: 700px) {
+  .mobile-plan-stepper {
+    display: block;
+    padding: 14px 14px 10px;
+    border-bottom: 1px solid var(--border);
+    background: var(--sand-50);
+  }
+
+  body[data-mobile-view="care"] .mobile-plan-stepper,
+  body[data-mobile-view="saved"] .mobile-plan-stepper {
+    display: none;
+  }
+
+  .mobile-plan-progress-row {
+    display: grid;
+    grid-template-columns: 1fr minmax(88px, 34%);
+    align-items: end;
+    gap: 14px;
+    margin-bottom: 10px;
+  }
+
+  .mobile-plan-progress-row .eyebrow {
+    margin-bottom: 3px;
+  }
+
+  .mobile-plan-progress-row strong {
+    color: var(--forest-950);
+    font-size: 0.86rem;
+  }
+
+  .mobile-plan-progress-track {
+    display: block;
+    height: 5px;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--sage-100);
+  }
+
+  .mobile-plan-progress-track span {
+    display: block;
+    width: var(--mobile-plan-progress, 33.333%);
+    height: 100%;
+    border-radius: inherit;
+    background: var(--forest-700);
+    transition: width 180ms ease;
+  }
+
+  .mobile-plan-steps {
+    display: grid;
+    gap: 7px;
+  }
+
+  .mobile-plan-step-button {
+    display: grid;
+    grid-template-columns: 34px minmax(0, 1fr);
+    align-items: center;
+    gap: 10px;
+    min-height: 54px;
+    padding: 8px 10px;
+    border: 1px solid transparent;
+    border-radius: 14px;
+    background: transparent;
+    color: var(--ink-700);
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .mobile-plan-step-button.is-active {
+    border-color: rgba(95, 127, 115, 0.26);
+    background: var(--white);
+    color: var(--forest-950);
+    box-shadow: 0 4px 14px rgba(47, 75, 67, 0.06);
+  }
+
+  .mobile-plan-step-number {
+    display: grid;
+    width: 32px;
+    height: 32px;
+    place-items: center;
+    border: 1px solid var(--border);
+    border-radius: 11px;
+    background: var(--sand-50);
+    color: var(--ink-500);
+    font-size: 0.76rem;
+    font-weight: 900;
+  }
+
+  .mobile-plan-step-button.is-active .mobile-plan-step-number {
+    border-color: rgba(95, 127, 115, 0.28);
+    background: var(--sage-100);
+    color: var(--forest-900);
+  }
+
+  .mobile-plan-step-button.is-complete .mobile-plan-step-number {
+    background: var(--forest-700);
+    color: var(--white);
+  }
+
+  .mobile-plan-step-button.is-complete .mobile-plan-step-number::before {
+    content: "✓";
+  }
+
+  .mobile-plan-step-button.is-complete .mobile-plan-step-number {
+    font-size: 0;
+  }
+
+  .mobile-plan-step-button.is-complete .mobile-plan-step-number::before {
+    font-size: 0.8rem;
+  }
+
+  .mobile-plan-step-copy,
+  .mobile-plan-step-copy strong,
+  .mobile-plan-step-copy small {
+    display: block;
+    min-width: 0;
+  }
+
+  .mobile-plan-step-copy strong {
+    font-size: 0.84rem;
+    line-height: 1.2;
+  }
+
+  .mobile-plan-step-copy small {
+    margin-top: 3px;
+    overflow: hidden;
+    color: var(--ink-500);
+    font-size: 0.68rem;
+    line-height: 1.25;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  body[data-mobile-view="plan"][data-mobile-plan-step="trip"] #care-plan-selection,
+  body[data-mobile-view="plan"][data-mobile-plan-step="trip"] .discovery-layout,
+  body[data-mobile-view="plan"][data-mobile-plan-step="trip"] .mobile-plan-review,
+  body[data-mobile-view="plan"][data-mobile-plan-step="care"] #hero-panel,
+  body[data-mobile-view="plan"][data-mobile-plan-step="care"] #care-plan-editor,
+  body[data-mobile-view="plan"][data-mobile-plan-step="care"] .mobile-plan-review,
+  body[data-mobile-view="plan"][data-mobile-plan-step="review"] #hero-panel,
+  body[data-mobile-view="plan"][data-mobile-plan-step="review"] #care-plan-editor,
+  body[data-mobile-view="plan"][data-mobile-plan-step="review"] #care-plan-selection,
+  body[data-mobile-view="plan"][data-mobile-plan-step="review"] .discovery-layout {
+    display: none !important;
+  }
+
+  body[data-mobile-view="plan"][data-mobile-plan-step="care"] #care-plan-selection,
+  body[data-mobile-view="plan"][data-mobile-plan-step="care"] .discovery-layout {
+    display: block;
+  }
+
+  body[data-mobile-view="plan"][data-mobile-plan-step="care"] .discovery-layout {
+    height: calc(100dvh - var(--mobile-header-height) - var(--mobile-nav-height) - 238px);
+    min-height: 430px;
+  }
+
+  body[data-mobile-view="plan"][data-mobile-plan-step="trip"] #save-care-plan,
+  body[data-mobile-view="plan"][data-mobile-plan-step="trip"] #clear-care-plan,
+  body[data-mobile-view="plan"][data-mobile-plan-step="trip"] .care-plan-saved-state,
+  body[data-mobile-view="plan"][data-mobile-plan-step="trip"] .care-plan-privacy-note {
+    display: none !important;
+  }
+
+  body[data-mobile-view="plan"][data-mobile-plan-step="trip"] .care-plan-editor-heading > div:last-child {
+    display: none;
+  }
+
+  body[data-mobile-view="plan"][data-mobile-plan-step="trip"] .care-plan-editor {
+    padding-top: 16px;
+  }
+
+  body[data-mobile-view="plan"][data-mobile-plan-step="trip"] .care-plan-editor-heading h2 {
+    font-size: 1.22rem;
+  }
+
+  .mobile-plan-stage-actions {
+    display: block;
+    margin-top: 18px;
+  }
+
+  .mobile-plan-stage-actions .button {
+    width: 100%;
+    min-height: 50px;
+    justify-content: center;
+  }
+
+  .mobile-plan-care-actions {
+    margin-top: 14px;
+  }
+
+  body[data-mobile-plan-step="trip"] .mobile-plan-care-actions,
+  body[data-mobile-plan-step="review"] .mobile-plan-care-actions {
+    display: none;
+  }
+
+  .mobile-plan-review {
+    min-height: calc(100dvh - var(--mobile-header-height) - var(--mobile-nav-height) - 190px);
+    padding: 18px 16px 28px;
+    border-top: 1px solid var(--border);
+    background: var(--sand-50);
+  }
+
+  body[data-mobile-view="plan"][data-mobile-plan-step="review"] .mobile-plan-review {
+    display: block;
+  }
+
+  .mobile-plan-review-heading h2 {
+    margin: 2px 0 7px;
+    color: var(--forest-950);
+    font-size: 1.32rem;
+  }
+
+  .mobile-plan-review-heading > p:last-child {
+    margin: 0;
+    color: var(--ink-700);
+    font-size: 0.82rem;
+    line-height: 1.45;
+  }
+
+  .mobile-plan-review-card {
+    margin-top: 14px;
+    padding: 14px;
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    background: var(--white);
+  }
+
+  .mobile-plan-review-card-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+
+  .mobile-plan-review-card-heading > strong {
+    color: var(--forest-950);
+    font-size: 0.9rem;
+  }
+
+  .mobile-plan-review-details {
+    display: grid;
+    gap: 10px;
+  }
+
+  .mobile-plan-review-details > div {
+    display: grid;
+    gap: 3px;
+  }
+
+  .mobile-plan-review-details span {
+    color: var(--ink-500);
+    font-size: 0.66rem;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .mobile-plan-review-details strong {
+    color: var(--ink-900);
+    font-size: 0.82rem;
+    line-height: 1.4;
+  }
+
+  .mobile-plan-review-facilities {
+    display: grid;
+    gap: 10px;
+  }
+
+  .mobile-plan-review-facilities > div {
+    display: grid;
+    gap: 7px;
+    padding: 11px;
+    border-radius: 13px;
+    background: var(--sand-50);
+  }
+
+  .mobile-plan-review-facilities strong {
+    color: var(--forest-950);
+    font-size: 0.84rem;
+  }
+
+  .mobile-plan-review-note {
+    margin: 14px 2px;
+    color: var(--ink-500);
+    font-size: 0.72rem;
+    line-height: 1.45;
+  }
+
+  .mobile-plan-review-save {
+    width: 100%;
+    min-height: 52px;
+    justify-content: center;
+  }
+
+  .mobile-plan-review-save:disabled {
+    opacity: 0.48;
+    cursor: not-allowed;
+  }
+
+  .mobile-plan-step-button:focus-visible {
+    outline: 3px solid rgba(95, 127, 115, 0.46);
+    outline-offset: 2px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mobile-plan-progress-track span {
+    transition: none;
+  }
+}

--- a/mobile-plan.js
+++ b/mobile-plan.js
@@ -1,0 +1,279 @@
+const MOBILE_PLAN_QUERY = window.matchMedia("(max-width: 700px)");
+
+let mobilePlanStep = "trip";
+let mobilePlanElements = {};
+const originalSetMobileViewForPlanStepper = setMobileView;
+
+setMobileView = function setMobileViewWithPlanStepper(view, moveFocus = true) {
+  originalSetMobileViewForPlanStepper(view, moveFocus);
+  if (!MOBILE_PLAN_QUERY.matches || view !== "plan") return;
+  const preferredStep = hasSavedCarePlan && activeStoredPlan ? "review" : mobilePlanStep;
+  setMobilePlanStep(preferredStep, false);
+};
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initializeMobilePlanStepper);
+} else {
+  initializeMobilePlanStepper();
+}
+
+function initializeMobilePlanStepper() {
+  injectMobilePlanStepper();
+  injectMobilePlanReview();
+  injectMobilePlanContinueActions();
+
+  mobilePlanElements = {
+    shell: document.getElementById("mobile-plan-stepper"),
+    progress: document.getElementById("mobile-plan-progress"),
+    buttons: [...document.querySelectorAll(".mobile-plan-step-button[data-plan-step]")],
+    tripSummary: document.getElementById("mobile-plan-trip-summary"),
+    careSummary: document.getElementById("mobile-plan-care-summary"),
+    reviewSummary: document.getElementById("mobile-plan-review-summary"),
+    tripContinue: document.getElementById("mobile-plan-trip-continue"),
+    careContinue: document.getElementById("mobile-plan-care-continue"),
+    review: document.getElementById("mobile-plan-review"),
+    reviewTrip: document.getElementById("mobile-plan-review-trip"),
+    reviewPrimary: document.getElementById("mobile-plan-review-primary"),
+    reviewBackup: document.getElementById("mobile-plan-review-backup"),
+    reviewEditTrip: document.getElementById("mobile-plan-review-edit-trip"),
+    reviewEditCare: document.getElementById("mobile-plan-review-edit-care"),
+    reviewSave: document.getElementById("mobile-plan-review-save"),
+    status: document.getElementById("mobile-plan-step-status"),
+  };
+
+  mobilePlanElements.buttons.forEach((button) => {
+    button.addEventListener("click", () => setMobilePlanStep(button.dataset.planStep));
+  });
+  mobilePlanElements.tripContinue.addEventListener("click", continueFromTripStep);
+  mobilePlanElements.careContinue.addEventListener("click", continueFromCareStep);
+  mobilePlanElements.reviewEditTrip.addEventListener("click", () => setMobilePlanStep("trip"));
+  mobilePlanElements.reviewEditCare.addEventListener("click", () => setMobilePlanStep("care"));
+  mobilePlanElements.reviewSave.addEventListener("click", () => {
+    document.getElementById("save-care-plan")?.click();
+    window.setTimeout(syncMobilePlanStepper, 0);
+  });
+
+  document.getElementById("care-plan-form")?.addEventListener("input", syncMobilePlanStepper);
+  document.getElementById("care-plan-form")?.addEventListener("change", syncMobilePlanStepper);
+  document.addEventListener("click", (event) => {
+    if (event.target.closest?.("[data-selection-action], .plan-role-button, #primary-selection-remove, #backup-selection-remove")) {
+      window.setTimeout(syncMobilePlanStepper, 0);
+    }
+  });
+  window.addEventListener("storage", (event) => {
+    if (event.key === CARE_PLAN_STORAGE_KEY) window.setTimeout(syncMobilePlanStepper, 0);
+  });
+
+  MOBILE_PLAN_QUERY.addEventListener?.("change", () => {
+    if (MOBILE_PLAN_QUERY.matches && mobileView === "plan") setMobilePlanStep(mobilePlanStep, false);
+  });
+
+  setMobilePlanStep(hasSavedCarePlan && activeStoredPlan ? "review" : "trip", false);
+  syncMobilePlanStepper();
+}
+
+function injectMobilePlanStepper() {
+  if (document.getElementById("mobile-plan-stepper")) return;
+  const shell = document.createElement("section");
+  shell.id = "mobile-plan-stepper";
+  shell.className = "mobile-plan-stepper";
+  shell.setAttribute("aria-label", "Care plan progress");
+  shell.innerHTML = `
+    <div class="mobile-plan-progress-row">
+      <div>
+        <p class="eyebrow">Build your care plan</p>
+        <strong id="mobile-plan-progress">Step 1 of 3</strong>
+      </div>
+      <span class="mobile-plan-progress-track" aria-hidden="true"><span></span></span>
+    </div>
+    <div class="mobile-plan-steps">
+      <button class="mobile-plan-step-button is-active" type="button" data-plan-step="trip" aria-expanded="true">
+        <span class="mobile-plan-step-number">1</span>
+        <span class="mobile-plan-step-copy"><strong>Trip & pet</strong><small id="mobile-plan-trip-summary">Add trip details</small></span>
+      </button>
+      <button class="mobile-plan-step-button" type="button" data-plan-step="care" aria-expanded="false">
+        <span class="mobile-plan-step-number">2</span>
+        <span class="mobile-plan-step-copy"><strong>Choose care</strong><small id="mobile-plan-care-summary">Primary and Backup needed</small></span>
+      </button>
+      <button class="mobile-plan-step-button" type="button" data-plan-step="review" aria-expanded="false">
+        <span class="mobile-plan-step-number">3</span>
+        <span class="mobile-plan-step-copy"><strong>Review & save</strong><small id="mobile-plan-review-summary">Finish earlier steps first</small></span>
+      </button>
+    </div>
+    <p id="mobile-plan-step-status" class="sr-only" role="status" aria-live="polite"></p>
+  `;
+  document.getElementById("hero-panel")?.insertAdjacentElement("beforebegin", shell);
+}
+
+function injectMobilePlanContinueActions() {
+  if (!document.getElementById("mobile-plan-trip-continue")) {
+    const tripActions = document.createElement("div");
+    tripActions.className = "mobile-plan-stage-actions";
+    tripActions.innerHTML = `<button id="mobile-plan-trip-continue" class="button button-primary" type="button">Continue to care options</button>`;
+    document.getElementById("care-plan-editor")?.append(tripActions);
+  }
+
+  if (!document.getElementById("mobile-plan-care-continue")) {
+    const careActions = document.createElement("div");
+    careActions.className = "mobile-plan-stage-actions mobile-plan-care-actions";
+    careActions.innerHTML = `<button id="mobile-plan-care-continue" class="button button-primary" type="button">Review plan</button>`;
+    document.getElementById("care-plan-selection")?.append(careActions);
+  }
+}
+
+function injectMobilePlanReview() {
+  if (document.getElementById("mobile-plan-review")) return;
+  const review = document.createElement("section");
+  review.id = "mobile-plan-review";
+  review.className = "mobile-plan-review";
+  review.hidden = true;
+  review.innerHTML = `
+    <div class="mobile-plan-review-heading">
+      <p class="eyebrow">Review & save</p>
+      <h2>Your trip care plan</h2>
+      <p>Confirm the details below before saving this plan to your device.</p>
+    </div>
+    <article class="mobile-plan-review-card">
+      <div class="mobile-plan-review-card-heading"><strong>Trip & pet</strong><button id="mobile-plan-review-edit-trip" class="text-button" type="button">Edit</button></div>
+      <div id="mobile-plan-review-trip" class="mobile-plan-review-details"></div>
+    </article>
+    <article class="mobile-plan-review-card">
+      <div class="mobile-plan-review-card-heading"><strong>Care choices</strong><button id="mobile-plan-review-edit-care" class="text-button" type="button">Edit</button></div>
+      <div class="mobile-plan-review-facilities">
+        <div><span class="selection-role-label is-primary">Primary</span><strong id="mobile-plan-review-primary">Not selected</strong></div>
+        <div><span class="selection-role-label is-backup">Backup</span><strong id="mobile-plan-review-backup">Not selected</strong></div>
+      </div>
+    </article>
+    <p class="mobile-plan-review-note">Call ahead to confirm services, hours, and availability before relying on a facility.</p>
+    <button id="mobile-plan-review-save" class="button button-primary mobile-plan-review-save" type="button">Save care plan</button>
+  `;
+  document.getElementById("care-plan-selection")?.insertAdjacentElement("afterend", review);
+}
+
+function setMobilePlanStep(step, moveFocus = true) {
+  if (!["trip", "care", "review"].includes(step)) return;
+  mobilePlanStep = step;
+  document.body.dataset.mobilePlanStep = step;
+
+  mobilePlanElements.buttons?.forEach((button) => {
+    const active = button.dataset.planStep === step;
+    button.classList.toggle("is-active", active);
+    button.setAttribute("aria-expanded", String(active));
+  });
+
+  const stepIndex = { trip: 1, care: 2, review: 3 }[step];
+  if (mobilePlanElements.progress) mobilePlanElements.progress.textContent = `Step ${stepIndex} of 3`;
+  document.documentElement.style.setProperty("--mobile-plan-progress", `${stepIndex * 33.333}%`);
+  syncMobilePlanStepper();
+
+  if (step === "care") setMobileDiscoveryView("results", false);
+  if (moveFocus) {
+    const target = step === "trip"
+      ? document.getElementById("trip-name")
+      : step === "care"
+        ? document.getElementById("care-plan-selection-title")
+        : document.querySelector("#mobile-plan-review h2");
+    window.setTimeout(() => target?.focus?.({ preventScroll: true }), 0);
+  }
+  window.scrollTo({ top: 0, behavior: prefersReducedMotion?.() ? "auto" : "smooth" });
+}
+
+function continueFromTripStep() {
+  const issue = validateMobileTripStage();
+  if (issue) {
+    announceMobilePlanStep(issue.message);
+    issue.element?.focus();
+    return;
+  }
+  setMobilePlanStep("care");
+  announceMobilePlanStep("Trip details complete. Choose a Primary and Backup facility.");
+}
+
+function continueFromCareStep() {
+  if (!planSelections.primary || !planSelections.backup) {
+    announceMobilePlanStep("Choose both a Primary and a distinct Backup facility before reviewing your plan.");
+    return;
+  }
+  setMobilePlanStep("review");
+  announceMobilePlanStep("Care choices complete. Review your plan before saving.");
+}
+
+function validateMobileTripStage() {
+  const name = document.getElementById("trip-name");
+  const destination = document.getElementById("trip-destination");
+  const start = document.getElementById("trip-start-date");
+  const end = document.getElementById("trip-end-date");
+  if (!name?.value.trim()) return { message: "Add a trip name before continuing.", element: name };
+  if (!destination?.value.trim()) return { message: "Add a destination before continuing.", element: destination };
+  if (start?.value && end?.value && end.value < start.value) return { message: "The trip end date cannot be before the start date.", element: end };
+  return null;
+}
+
+function syncMobilePlanStepper() {
+  if (!mobilePlanElements.shell) return;
+  const name = document.getElementById("trip-name")?.value.trim() || "";
+  const destination = document.getElementById("trip-destination")?.value.trim() || "";
+  const pet = document.getElementById("pet-name")?.value.trim() || "";
+  const tripReady = !validateMobileTripStage();
+  const careReady = Boolean(planSelections.primary && planSelections.backup);
+
+  if (mobilePlanElements.tripSummary) {
+    mobilePlanElements.tripSummary.textContent = tripReady
+      ? [name, pet || destination].filter(Boolean).join(" · ")
+      : "Add trip details";
+  }
+  if (mobilePlanElements.careSummary) {
+    mobilePlanElements.careSummary.textContent = careReady
+      ? `${planSelections.primary.name} · Backup ready`
+      : planSelections.primary
+        ? "Primary selected · Backup needed"
+        : "Primary and Backup needed";
+  }
+  if (mobilePlanElements.reviewSummary) {
+    mobilePlanElements.reviewSummary.textContent = tripReady && careReady ? "Ready to review" : "Finish earlier steps first";
+  }
+
+  mobilePlanElements.buttons?.forEach((button) => {
+    const step = button.dataset.planStep;
+    button.classList.toggle("is-complete", step === "trip" ? tripReady : step === "care" ? careReady : hasSavedCarePlan);
+  });
+
+  if (mobilePlanElements.reviewTrip) {
+    const dates = formatMobilePlanDates(
+      document.getElementById("trip-start-date")?.value || "",
+      document.getElementById("trip-end-date")?.value || ""
+    );
+    mobilePlanElements.reviewTrip.innerHTML = [
+      ["Trip", name || "Not added"],
+      ["Destination", destination || "Not added"],
+      ["Dates", dates],
+      ["Pet", pet || "Not added"],
+      ["Owner phone", document.getElementById("owner-phone")?.value.trim() || "Not added"],
+      ["Important note", document.getElementById("pet-note")?.value.trim() || "No note added"],
+    ].map(([label, value]) => `<div><span>${escapeHtml(label)}</span><strong>${escapeHtml(value)}</strong></div>`).join("");
+  }
+  if (mobilePlanElements.reviewPrimary) mobilePlanElements.reviewPrimary.textContent = planSelections.primary?.name || "Not selected";
+  if (mobilePlanElements.reviewBackup) mobilePlanElements.reviewBackup.textContent = planSelections.backup?.name || "Not selected";
+  if (mobilePlanElements.reviewSave) {
+    mobilePlanElements.reviewSave.disabled = !(tripReady && careReady);
+    mobilePlanElements.reviewSave.textContent = hasSavedCarePlan ? "Update care plan" : "Save care plan";
+  }
+}
+
+function announceMobilePlanStep(message) {
+  if (!mobilePlanElements.status) return;
+  mobilePlanElements.status.textContent = "";
+  window.requestAnimationFrame(() => { mobilePlanElements.status.textContent = message; });
+}
+
+function formatMobilePlanDates(start, end) {
+  if (!start && !end) return "Not added";
+  if (start && !end) return `Starts ${formatMobilePlanDate(start)}`;
+  if (!start && end) return `Ends ${formatMobilePlanDate(end)}`;
+  return `${formatMobilePlanDate(start)} – ${formatMobilePlanDate(end)}`;
+}
+
+function formatMobilePlanDate(value) {
+  const date = new Date(`${value}T12:00:00`);
+  return date.toLocaleDateString([], { month: "short", day: "numeric", year: "numeric" });
+}


### PR DESCRIPTION
## Summary

- replaces the long mobile Plan scroll with a three-stage guided workflow: Trip & pet, Choose care, Review & save
- keeps only one planning stage expanded at a time
- collapses completed stages into concise summaries while preserving entered values
- hides results and map until the Choose care stage
- keeps Primary / Backup selection and the existing Results / Map switcher intact
- adds a dedicated mobile review surface before save/update
- lets users reopen Trip or Care stages to edit without losing data
- leaves Care Now, Saved Plan, desktop/tablet behavior, and `pawpath.activeCarePlan.v1` unchanged

## Why this strengthens PawPath

The planning experience now behaves like a focused preparedness task instead of exposing the editor, selections, results, and map as one continuous mobile page. It preserves PawPath's flexible web architecture while making the main planning workflow much closer to an application flow.

## Technical approach

- `mobile-plan.js` adds mobile-only step state, progress, summaries, stage validation, review, and navigation
- `mobile-plan.css` scopes the guided workflow to phone widths and changes which existing surfaces are visible per stage
- `map-layout-fix.js` loads the new mobile Plan modules after the existing saved-plan/mobile-shell integration chain
- no schema, backend, framework, or desktop HTML changes

## Validation

- compared the branch directly against current `main`
- changes are limited to the mobile Plan module/style additions and late-module loading order
- existing care-plan validation remains the final authority when saving
- Primary / Backup selection state continues to use the existing `planSelections` model
- the existing care-plan form fields remain the source of truth, so collapsing/reopening stages does not recreate or discard field values

## Browser testing still required

The repository has no automated browser-test suite. Deployed phone-width testing is still required for stage transitions, scrolling, focus, Results / Map height, facility selection, saved-plan restore/edit behavior, and iOS/Android viewport behavior.

Closes #40