### PR TITLE
Update handoff for guided mobile Plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ PawPath is a mobile-friendly web application for campers, RV travelers, road-tri
 
 [Open PawPath](https://jeffthomasiii.github.io/pawpath/)
 
-The proof of concept now presents two functionally distinct workflows. **Plan a Trip** lets users enter trip details, choose Primary and Backup facilities, and save one active care plan locally in the browser. **Find Care Now** hides the planning form and focuses on immediate nearby-care search. A saved plan can also open **Emergency Mode**, which removes unrelated planning and map controls, presents the saved Primary facility first with immediate Call and Directions actions, keeps the Backup directly below, and shows saved pet and owner details with call-ahead guidance. When the normal nearby search contains no emergency or urgent-care option, PawPath also checks a 30-mile fallback radius and either adds the nearest qualifying listing or clearly explains that OpenStreetMap could not identify one.
+The proof of concept now presents two functionally distinct workflows. **Plan a Trip** lets users enter trip details, choose Primary and Backup facilities, and save one active care plan locally in the browser. At phone widths, Plan now uses a three-stage guided workflow — **Trip & pet → Choose care → Review & save** — so the editor, selections, results, and map are not exposed as one long continuous page. **Find Care Now** hides the planning form and focuses on immediate nearby-care search. A saved plan can also open **Emergency Mode**, which removes unrelated planning and map controls, presents the saved Primary facility first with immediate Call and Directions actions, keeps the Backup directly below, and shows saved pet and owner details with call-ahead guidance. When the normal nearby search contains no emergency or urgent-care option, PawPath also checks a 30-mile fallback radius and either adds the nearest qualifying listing or clearly explains that OpenStreetMap could not identify one.
 
 ## Why PawPath?
 
@@ -37,7 +37,7 @@ PawPath is organized around two core experiences:
 
 ### Plan a Trip
 
-Search around a campground, destination, ZIP code, or overnight stop; enter trip and pet details; choose a Primary facility and Backup; and save the essential information before leaving.
+Search around a campground, destination, ZIP code, or overnight stop; enter trip and pet details; choose a Primary facility and Backup; and save the essential information before leaving. On mobile, the workflow is progressive: complete trip details, choose care, then review and save.
 
 ### Find Care Now
 
@@ -50,6 +50,11 @@ Open the saved care plan as a focused call-and-go view. The Primary facility app
 ## Current capabilities
 
 - Switch between Plan a Trip and Find Care Now modes
+- Use a phone-only app shell with compact header and persistent Plan / Care Now / Saved navigation
+- Use a guided three-stage mobile Plan workflow with one active stage at a time
+- Collapse completed mobile Plan stages into concise summaries without discarding entered data
+- Reveal Results / Map only during the mobile Choose care stage
+- Review trip and Primary / Backup choices before mobile save/update
 - Show a trip-plan editor only in Plan a Trip mode
 - Save one active care plan to browser `localStorage` using `pawpath.activeCarePlan.v1`
 - Store a trip name, destination, optional dates, pet name, owner phone, and one brief important note
@@ -82,7 +87,7 @@ Open the saved care plan as a focused call-and-go view. The Primary facility app
 - Filter results between all care, emergency, and routine clinics
 - Open driving directions without embedding a paid map service
 - Responsive desktop, tablet, and mobile layouts
-- Keyboard-accessible mode controls, search controls, cards, selections, forms, detail drawer, saved-plan actions, Emergency Mode, and map markers
+- Keyboard-accessible mode controls, mobile planning steps, search controls, cards, selections, forms, detail drawer, saved-plan actions, Emergency Mode, and map markers
 - PawPath branded header and favicon
 
 ## Next proof-of-concept capabilities
@@ -111,6 +116,7 @@ The next implementation task is [POC-07: Add curated demonstration data](https:/
 - [Phase 1 Backlog](docs/BACKLOG.md) — prioritized POC work packages
 - [Phase 1 Release Plan](docs/PHASE_1_RELEASE_PLAN.md) — increments, release gate, and manual checklist
 - [Implementation Notes](docs/IMPLEMENTATION_NOTES.md) — data objects, state model, storage, confidence logic, and file guidance
+- [Mobile Web App](docs/MOBILE_WEB_APP.md) — mobile application-shell direction and constraints
 - [Demo Script](docs/DEMO_SCRIPT.md) — two-minute walkthrough and early-user feedback questions
 
 ## Technologies
@@ -140,13 +146,18 @@ pawpath/
 ├── emergency-fallback.css   # Extended emergency-result presentation
 ├── brand-refresh.css        # Approved PawPath visual alignment layer
 ├── plan-summary.css         # Saved-plan summary and focused Emergency Mode presentation
+├── mobile-app.css           # Phone-only application shell and task views
+├── mobile-plan.css          # Guided mobile Plan stages and review surface
 ├── leaflet-local.css        # Locally hosted Leaflet layout styles
 ├── app.js                   # Modes, map, facility classification, detail rendering, search, filters, and UI state
 ├── emergency-fallback.js    # Conditional 30-mile emergency and urgent-care fallback search
 ├── selection.js             # Primary and Backup care-plan selection
 ├── care-plan.js             # Versioned local storage, validation, restore, update, and clear behavior
 ├── plan-summary.js          # Persistent saved-plan summary and Emergency Mode behavior
-├── map-layout-fix.js        # Saved-plan integration loading and defensive Leaflet resize handling
+├── mobile-app.js            # Phone app shell, bottom navigation, Saved, and Results / Map task views
+├── mobile-app-sync.js       # Keeps mobile saved-plan state synchronized with persistence
+├── mobile-plan.js           # Guided mobile Plan state, progress, summaries, and review behavior
+├── map-layout-fix.js        # Late integration loading and defensive Leaflet resize handling
 └── README.md                # Project overview
 ```
 

--- a/docs/chatgpt-project/CURRENT_STATE.md
+++ b/docs/chatgpt-project/CURRENT_STATE.md
@@ -31,6 +31,10 @@ Last updated: August 2026
   - trip-plan editor
   - Primary and Backup selection controls
   - save and update one active care plan
+  - phone-only guided workflow: **Trip & pet → Choose care → Review & save**
+  - only one mobile planning stage is expanded at a time
+  - Results / Map appear only during the mobile Choose care stage
+  - completed stages collapse into concise summaries without recreating or discarding field values
 - **Find Care Now**
   - immediate-care language
   - current-location emphasis
@@ -43,6 +47,17 @@ Last updated: August 2026
   - hides map exploration, filters, search, and planning controls while active
   - provides call-ahead and availability guidance without diagnosis or treatment claims
   - supports explicit exit, Escape-key exit, and focus restoration
+
+### Mobile web-app shell
+
+- Phone-only compact PawPath app header
+- Persistent bottom navigation for **Plan**, **Care Now**, and **Saved**
+- Dedicated Saved Plan destination without scrolling through the main page
+- Results / Map switcher so mobile discovery uses one primary task surface at a time
+- Facility detail presented as a near-full-height mobile bottom sheet
+- Emergency Mode presented as a full-height mobile takeover
+- Mobile planning stepper with progress, stage summaries, back-editing, and a dedicated review surface
+- Existing desktop/tablet presentation remains separate and unchanged by the mobile-only shell rules
 
 ### Facility evaluation
 
@@ -110,6 +125,8 @@ Completed:
 - POC-04: Persistent active care plan
 - POC-05: Persistent saved-plan summary
 - POC-06: Full Emergency Mode
+- POC-06.5: Mobile web-app shell
+- POC-06.6: Guided mobile Plan workflow
 
 Next:
 
@@ -124,6 +141,8 @@ Remaining after curated demonstration data:
 
 - Phase 1 tracker: Issue #13
 - Full Emergency Mode: Issue #9 — completed
+- Mobile web-app shell: Issue #36 — completed
+- Guided mobile Plan workflow: Issue #40 — completed
 - Curated demo data: Issue #10
 - Printable emergency card: Issue #11
 - Shareable POC validation: Issue #12
@@ -143,15 +162,20 @@ Current major files include:
 - `emergency-fallback.css`
 - `brand-refresh.css`
 - `plan-summary.css`
+- `mobile-app.css`
+- `mobile-plan.css`
 - `leaflet-local.css`
 - `app.js`
 - `emergency-fallback.js`
 - `selection.js`
 - `care-plan.js`
 - `plan-summary.js`
+- `mobile-app.js`
+- `mobile-app-sync.js`
+- `mobile-plan.js`
 - `map-layout-fix.js`
 
-`map-layout-fix.js` dynamically loads `plan-summary.css` and `plan-summary.js` after the core care-plan module. The full Emergency Mode remains implemented inside the saved-plan summary module so it uses the same validated stored-plan state without introducing a second storage model.
+`map-layout-fix.js` dynamically loads the late integration modules after the core care-plan module. The order is saved-plan summary, mobile app shell, mobile saved-plan synchronization, then the mobile Plan stepper. This ordering matters because later modules extend shared global functions.
 
 ## Known limitations and risks
 
@@ -166,7 +190,7 @@ Current major files include:
 - No user accounts, cloud sync, or multi-plan storage
 - Several modules wrap global functions; careless script-order changes can break behavior
 - Browser geolocation and remote API behavior require deployed or local-server testing
-- Emergency Mode still requires deployed desktop and mobile browser validation for focus behavior, phone links, directions, restored plans, and responsive layout
+- The mobile web-app shell and guided Plan workflow require deployed iPhone Safari and Android Chrome validation, especially for viewport height, safe areas, stage transitions, Leaflet resizing, focus, and restored saved-plan editing
 
 ## Immediate implementation objective
 


### PR DESCRIPTION
## Summary

- documents the completed guided mobile Plan workflow in the README
- updates the current-state handoff with the mobile stepper, review flow, and late-module loading order
- keeps POC-07 curated demonstration data as the next roadmap increment

## Validation

- documentation only; no application behavior changes
- content matches merged PR #42 and tracking Issue #13