### PR TITLE
Compact mobile planner and fix clipped care controls

### DIFF
--- a/map-layout-fix.js
+++ b/map-layout-fix.js
@@ -15,6 +15,11 @@ mobilePlanStylesheet.rel = "stylesheet";
 mobilePlanStylesheet.href = "mobile-plan.css";
 document.head.append(mobilePlanStylesheet);
 
+const mobilePolishStylesheet = document.createElement("link");
+mobilePolishStylesheet.rel = "stylesheet";
+mobilePolishStylesheet.href = "mobile-polish.css";
+document.head.append(mobilePolishStylesheet);
+
 const planSummaryScript = document.createElement("script");
 planSummaryScript.src = "plan-summary.js";
 planSummaryScript.async = false;
@@ -30,6 +35,12 @@ planSummaryScript.addEventListener("load", () => {
       const mobilePlanScript = document.createElement("script");
       mobilePlanScript.src = "mobile-plan.js";
       mobilePlanScript.async = false;
+      mobilePlanScript.addEventListener("load", () => {
+        const mobilePolishScript = document.createElement("script");
+        mobilePolishScript.src = "mobile-polish.js";
+        mobilePolishScript.async = false;
+        document.head.append(mobilePolishScript);
+      });
       document.head.append(mobilePlanScript);
     });
     document.head.append(mobileAppSyncScript);

--- a/mobile-polish.css
+++ b/mobile-polish.css
@@ -1,0 +1,77 @@
+/* Deployed-device mobile refinements for the guided planner and discovery controls. */
+
+@media (max-width: 700px) {
+  .mobile-plan-stepper {
+    padding: 12px 12px 9px;
+  }
+
+  .mobile-plan-progress-row {
+    grid-template-columns: 1fr minmax(92px, 32%);
+    gap: 10px;
+    margin-bottom: 8px;
+  }
+
+  .mobile-plan-steps {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 6px;
+  }
+
+  .mobile-plan-step-button {
+    display: grid;
+    grid-template-columns: 1fr;
+    justify-items: center;
+    gap: 5px;
+    min-width: 0;
+    min-height: 66px;
+    padding: 7px 5px;
+    text-align: center;
+  }
+
+  .mobile-plan-step-number {
+    width: 27px;
+    height: 27px;
+    border-radius: 9px;
+    font-size: 0.7rem;
+  }
+
+  .mobile-plan-step-copy {
+    width: 100%;
+  }
+
+  .mobile-plan-step-copy strong {
+    font-size: 0.7rem;
+    line-height: 1.15;
+  }
+
+  .mobile-plan-step-copy small {
+    display: none;
+  }
+
+  body[data-mobile-view="plan"][data-mobile-plan-step="care"] .discovery-layout {
+    height: calc(100dvh - var(--mobile-header-height) - var(--mobile-nav-height) - 206px);
+    min-height: 440px;
+  }
+
+  .mobile-discovery-switcher {
+    top: 12px;
+  }
+
+  .results-panel {
+    padding-top: 74px;
+    scroll-padding-top: 74px;
+  }
+
+  .results-heading {
+    scroll-margin-top: 74px;
+  }
+
+  .filter-row {
+    top: 0;
+    margin-top: 2px;
+    padding: 10px 0 9px;
+  }
+
+  .filter-chip {
+    min-height: 42px;
+  }
+}

--- a/mobile-polish.js
+++ b/mobile-polish.js
@@ -1,0 +1,34 @@
+/* Keep mobile discovery controls from reopening at a retained inner-scroll position. */
+
+const MOBILE_POLISH_QUERY = window.matchMedia("(max-width: 700px)");
+
+function resetMobileResultsScroll() {
+  if (!MOBILE_POLISH_QUERY.matches) return;
+  const resultsPanel = document.querySelector(".results-panel");
+  if (!resultsPanel) return;
+  resultsPanel.scrollTo({ top: 0, behavior: "auto" });
+}
+
+function scheduleMobileResultsReset() {
+  window.requestAnimationFrame(() => {
+    resetMobileResultsScroll();
+    window.setTimeout(resetMobileResultsScroll, 80);
+  });
+}
+
+document.addEventListener("click", (event) => {
+  const mobileNav = event.target.closest?.(".mobile-nav-button[data-mobile-view]");
+  if (mobileNav?.dataset.mobileView === "care") scheduleMobileResultsReset();
+
+  const discoveryButton = event.target.closest?.(".mobile-discovery-button[data-mobile-discovery]");
+  if (discoveryButton?.dataset.mobileDiscovery === "results") scheduleMobileResultsReset();
+
+  const planStep = event.target.closest?.(".mobile-plan-step-button[data-plan-step]");
+  if (planStep?.dataset.planStep === "care") scheduleMobileResultsReset();
+
+  if (event.target.closest?.("#mobile-plan-trip-continue")) scheduleMobileResultsReset();
+});
+
+MOBILE_POLISH_QUERY.addEventListener?.("change", (event) => {
+  if (event.matches) scheduleMobileResultsReset();
+});


### PR DESCRIPTION
## Summary

- compacts the three guided Plan steps into one horizontal row at phone widths
- preserves the existing step progress bar and active/completed states
- adds extra top clearance around the Results / Map switcher and filter chips
- resets the internal results-panel scroll position when entering Care Now, entering Plan → Choose care, or switching back to Results
- keeps the existing storage schema, care-plan behavior, Saved Plan, Emergency Mode, and desktop/tablet presentation unchanged

## Validation

- based on deployed Android screenshots showing excessive vertical stepper height and clipped/retained results controls
- branch is based directly on current `main`
- changes are isolated to late-loaded mobile polish CSS/JS and loader order
- no HTML IDs or `pawpath.activeCarePlan.v1` schema changes

## Browser testing still required

Please re-check the deployed site on the same Android device, especially Plan → Choose care, Care Now, filter chips, Results ↔ Map, and browser UI resizing.

Closes #44