### PR TITLE
Fix mobile care-filter clipping across shorter viewports

### DIFF
--- a/map-layout-fix.js
+++ b/map-layout-fix.js
@@ -20,6 +20,11 @@ mobilePolishStylesheet.rel = "stylesheet";
 mobilePolishStylesheet.href = "mobile-polish.css";
 document.head.append(mobilePolishStylesheet);
 
+const mobileDiscoveryLayoutStylesheet = document.createElement("link");
+mobileDiscoveryLayoutStylesheet.rel = "stylesheet";
+mobileDiscoveryLayoutStylesheet.href = "mobile-discovery-layout.css";
+document.head.append(mobileDiscoveryLayoutStylesheet);
+
 const planSummaryScript = document.createElement("script");
 planSummaryScript.src = "plan-summary.js";
 planSummaryScript.async = false;

--- a/mobile-discovery-layout.css
+++ b/mobile-discovery-layout.css
@@ -1,0 +1,61 @@
+/* Stable mobile discovery layout: reserve real space for Results / Map controls instead of overlaying them. */
+
+@media (max-width: 700px) {
+  .discovery-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto minmax(0, 1fr);
+    overflow: hidden;
+  }
+
+  .mobile-discovery-switcher {
+    position: relative;
+    z-index: 8;
+    top: auto;
+    left: auto;
+    grid-column: 1;
+    grid-row: 1;
+    width: min(244px, calc(100% - 28px));
+    margin: 10px auto 8px;
+    transform: none;
+  }
+
+  .results-panel,
+  .map-panel {
+    position: relative;
+    inset: auto;
+    grid-column: 1;
+    grid-row: 2;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+  }
+
+  .results-panel {
+    padding: 8px 14px 20px;
+    scroll-padding-top: 0;
+  }
+
+  .results-heading {
+    scroll-margin-top: 0;
+  }
+
+  .filter-row {
+    top: 0;
+    margin-top: 0;
+    padding: 8px 0 10px;
+  }
+
+  .filter-row > * {
+    flex-shrink: 0;
+  }
+
+  body[data-mobile-discovery="results"] .map-panel,
+  body[data-mobile-discovery="map"] .results-panel {
+    display: none;
+  }
+
+  body[data-mobile-discovery="map"] .map-panel {
+    display: block;
+  }
+}


### PR DESCRIPTION
## Summary

- replaces the overlapping absolute mobile discovery layers with a grid layout that reserves real space for the Results / Map switcher
- keeps Results / Map in a dedicated top row and the scrollable results/map surface below it
- removes the extra top-padding compensation that was required by the overlay approach
- keeps the filter row sticky within the results surface so All care / Emergency / Routine remain fully visible and tappable
- preserves Results ↔ Map switching, Care Now, Plan → Choose care, storage, Saved Plan, Emergency Mode, and desktop/tablet behavior

## Why

Deployed testing showed that shorter phone viewports (including Galaxy S23 Ultra and iPhone 12 Pro emulation) could clip the care filter buttons even though taller devices appeared correct. The previous design depended on absolute overlays plus hard-coded vertical padding, which was sensitive to viewport height and browser chrome.

## Validation

- branch is based directly on current `main`
- changes are limited to a mobile-only layout override plus stylesheet loading
- no HTML IDs, storage schema, care-plan state, or desktop styles are changed
- static review indicates the switcher and filter row now participate in normal layout flow instead of competing for the same vertical space

## Deployed testing still required

Re-check iPhone 12 Pro emulation, Galaxy S23 Ultra, Galaxy S20 Ultra Plan → Choose care, iPhone 14 Pro Max, and Results ↔ Map switching after GitHub Pages deploys.

Closes #47