### PR TITLE
Prevent emergency fallback notice from shifting mobile filters

### DIFF
--- a/mobile-discovery-layout.css
+++ b/mobile-discovery-layout.css
@@ -34,6 +34,7 @@
   .results-panel {
     padding: 8px 14px 20px;
     scroll-padding-top: 0;
+    overflow-anchor: none;
   }
 
   .results-heading {
@@ -48,6 +49,10 @@
 
   .filter-row > * {
     flex-shrink: 0;
+  }
+
+  .expanded-emergency-search-notice {
+    overflow-anchor: none;
   }
 
   body[data-mobile-discovery="results"] .map-panel,

--- a/mobile-polish.js
+++ b/mobile-polish.js
@@ -1,6 +1,7 @@
 /* Keep mobile discovery controls from reopening at a retained inner-scroll position. */
 
 const MOBILE_POLISH_QUERY = window.matchMedia("(max-width: 700px)");
+let mobileFallbackNoticeVisible = false;
 
 function resetMobileResultsScroll() {
   if (!MOBILE_POLISH_QUERY.matches) return;
@@ -14,6 +15,32 @@ function scheduleMobileResultsReset() {
     resetMobileResultsScroll();
     window.setTimeout(resetMobileResultsScroll, 80);
   });
+}
+
+function syncMobileFallbackNoticeState() {
+  const notice = document.getElementById("expanded-emergency-search-notice");
+  const isVisible = Boolean(notice && !notice.hidden);
+
+  if (isVisible && !mobileFallbackNoticeVisible) {
+    scheduleMobileResultsReset();
+  }
+
+  mobileFallbackNoticeVisible = isVisible;
+}
+
+function observeMobileFallbackNotice() {
+  const resultsPanel = document.querySelector(".results-panel");
+  if (!resultsPanel || !("MutationObserver" in window)) return;
+
+  const observer = new MutationObserver(syncMobileFallbackNoticeState);
+  observer.observe(resultsPanel, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["hidden"],
+  });
+
+  syncMobileFallbackNoticeState();
 }
 
 document.addEventListener("click", (event) => {
@@ -32,3 +59,9 @@ document.addEventListener("click", (event) => {
 MOBILE_POLISH_QUERY.addEventListener?.("change", (event) => {
   if (event.matches) scheduleMobileResultsReset();
 });
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", observeMobileFallbackNotice);
+} else {
+  observeMobileFallbackNotice();
+}


### PR DESCRIPTION
## Summary

- disables browser scroll anchoring inside the mobile Results panel
- watches the Expanded emergency search notice and resets the inner Results scroll only when that notice first becomes visible
- avoids repeated resets during ordinary result renders or user scrolling
- preserves the existing fallback notice, filters, Results / Map switching, Plan → Choose care, Care Now, storage, Emergency Mode, and desktop/tablet behavior

## Why

Device testing isolated the remaining clipping to the moment the dynamic Expanded emergency search notice appears. Because that notice is inserted after the sticky filter row, browser scroll anchoring can preserve lower content and shift the inner Results scroll position by roughly the height of the new notice. That makes the filter row look clipped even though the surrounding layout is correct.

## Validation

- branch is based directly on current `main`
- changes are limited to mobile discovery CSS and the existing mobile polish module
- no HTML IDs, storage schema, facility data, or desktop styles are changed
- reset is gated on the fallback notice transitioning from hidden to visible, so normal user scrolling is not continually overridden

## Deployed testing still required

Re-check searches that trigger Expanded emergency search on Galaxy S23 Ultra, iPhone 12 Pro emulation, and Galaxy S20 Ultra Plan → Choose care.

Closes #49