### PR TITLE
Stabilize Plan care filters and simplify result count

### DIFF
--- a/mobile-discovery-layout.css
+++ b/mobile-discovery-layout.css
@@ -38,7 +38,26 @@
   }
 
   .results-heading {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 10px;
     scroll-margin-top: 0;
+  }
+
+  .result-count {
+    display: block;
+    min-height: 0;
+    margin-top: 3px;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    color: var(--ink-500);
+    font-size: 0.72rem;
+    font-weight: 700;
+    line-height: 1.2;
+    white-space: nowrap;
   }
 
   .filter-row {
@@ -55,6 +74,20 @@
     overflow-anchor: none;
   }
 
+  /* Plan has a selection surface above discovery, unlike Care Now. Keep this
+     stage independent from viewport subtraction and avoid nested sticky clipping. */
+  body[data-mobile-view="plan"][data-mobile-plan-step="care"] .discovery-layout {
+    height: 560px;
+    min-height: 0;
+    max-height: none;
+  }
+
+  body[data-mobile-view="plan"][data-mobile-plan-step="care"] .filter-row {
+    position: relative;
+    z-index: 1;
+    top: auto;
+  }
+
   body[data-mobile-discovery="results"] .map-panel,
   body[data-mobile-discovery="map"] .results-panel {
     display: none;
@@ -62,5 +95,11 @@
 
   body[data-mobile-discovery="map"] .map-panel {
     display: block;
+  }
+}
+
+@media (max-width: 700px) and (max-height: 760px) {
+  body[data-mobile-view="plan"][data-mobile-plan-step="care"] .discovery-layout {
+    height: 500px;
   }
 }


### PR DESCRIPTION
## Summary

- fixes the remaining Plan → Choose care mobile filter clipping without changing Care Now
- gives the Plan care discovery surface a stable stage height instead of inheriting the earlier viewport-subtraction formula
- keeps the Plan filter row in normal flow so it cannot be clipped by sticky positioning inside that nested results scroller
- keeps emergency fallback notices below the filters without changing their messaging
- removes the mobile pill/badge treatment from the results count and keeps counts such as `2 results` on one line as subdued text

## Why

Device testing narrowed the remaining clipping to Plan → Choose care. That stage has the extra care-plan selection surface above discovery, so it does not share the same vertical context as Care Now. The nested sticky filter row was still vulnerable on shorter viewports even after fixing scroll anchoring.

## Validation

- branch is based directly on current `main`
- CSS-only change in the existing late-loaded mobile discovery layer
- Care Now sticky-filter behavior remains unchanged
- no storage schema, JavaScript state, facility data, HTML IDs, or desktop/tablet styles changed

## Deployed testing still required

Re-check Plan → Choose care with both yellow unresolved-emergency and red expanded-emergency notices on iPhone 12 Pro emulation, Galaxy S23 Ultra, and Galaxy S20 Ultra-class viewports. Also confirm the plain-text result count looks correct across one- and two-digit result totals.

Closes #51